### PR TITLE
New whitespace word tokenizer and punctuation filter

### DIFF
--- a/caterpillar/processing/analysis/analyse.py
+++ b/caterpillar/processing/analysis/analyse.py
@@ -3,8 +3,8 @@
 """Tools to perform analysis of text streams (aka tokenizing and filtering)."""
 from caterpillar.processing.analysis import stopwords
 from caterpillar.processing.analysis.filter import StopFilter, PositionalLowercaseWordFilter, BiGramFilter, \
-    PotentialBiGramFilter
-from caterpillar.processing.analysis.tokenize import WordTokenizer, EverythingTokenizer
+    PotentialBiGramFilter, OuterPunctuationFilter, PossessiveContractionFilter
+from caterpillar.processing.analysis.tokenize import WordTokenizer, EverythingTokenizer, SimpleWordTokenizer
 
 
 class Analyser(object):
@@ -46,14 +46,19 @@ class DefaultAnalyser(Analyser):
     stopword_list -- A list of stop words to override the default ``stopwords.ENGLISH`` one.
 
     """
-    _tokenizer = WordTokenizer(detect_compound_names=True)
+    _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
 
     def __init__(self, stopword_list=None):
         super(DefaultAnalyser, self).__init__()
         if stopword_list is None:
             stopword_list = stopwords.ENGLISH
 
-        self._filters = [StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE), PositionalLowercaseWordFilter(0)]
+        self._filters = [
+            OuterPunctuationFilter(leading_allow=['@', '#']),
+            PossessiveContractionFilter(),
+            StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
+            PositionalLowercaseWordFilter(0),
+        ]
 
     def get_tokenizer(self):
         return self._tokenizer
@@ -77,13 +82,18 @@ class BiGramAnalyser(Analyser):
     stopword_list -- A list of stop words to override the default English one.
 
     """
-    _tokenizer = WordTokenizer(detect_compound_names=True)
+    _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
 
     def __init__(self, bi_grams, stopword_list=None):
         if stopword_list is None:
             stopword_list = stopwords.ENGLISH
-        self._filters = [StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
-                         PositionalLowercaseWordFilter(0), BiGramFilter(bi_grams)]
+        self._filters = [
+            OuterPunctuationFilter(leading_allow=['@', '#']),
+            PossessiveContractionFilter(),
+            StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
+            PositionalLowercaseWordFilter(0),
+            BiGramFilter(bi_grams),
+        ]
 
     def get_tokenizer(self):
         return self._tokenizer
@@ -100,9 +110,14 @@ class PotentialBiGramAnalyser(Analyser):
     ``PotentialBiGramFilter`` to generate a stream of possible bi-grams.
 
     """
-    _tokenizer = WordTokenizer(detect_compound_names=True)
-    _filters = [StopFilter(stopwords.ENGLISH, minsize=stopwords.MIN_WORD_SIZE), PositionalLowercaseWordFilter(0),
-                PotentialBiGramFilter()]
+    _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
+    _filters = [
+        OuterPunctuationFilter(leading_allow=['@', '#']),
+        PossessiveContractionFilter(),
+        StopFilter(stopwords.ENGLISH, minsize=stopwords.MIN_WORD_SIZE),
+        PositionalLowercaseWordFilter(0),
+        PotentialBiGramFilter(),
+    ]
 
     def get_tokenizer(self):
         return self._tokenizer

--- a/caterpillar/processing/analysis/test/test_analyse.py
+++ b/caterpillar/processing/analysis/test/test_analyse.py
@@ -18,14 +18,14 @@ def test_base_analyse_class():
 def test_default_analyser():
     analyser = DefaultAnalyser()
 
-    assert len(analyser.get_filters()) == 2
+    assert len(analyser.get_filters()) == 4
     assert isinstance(analyser.get_tokenizer(), Tokenizer)
 
 
 def test_bigram_analyser():
     analyser = BiGramAnalyser([])
 
-    assert len(analyser.get_filters()) == 3
+    assert len(analyser.get_filters()) == 5
     assert isinstance(analyser.get_tokenizer(), Tokenizer)
 
 

--- a/caterpillar/processing/analysis/tokenize.py
+++ b/caterpillar/processing/analysis/tokenize.py
@@ -88,7 +88,7 @@ class RegexpTokenizer(Tokenizer):
         used: `regex.UNICODE | regex.MULTILINE | regex.DOTALL | regex.VERSION1`.
 
     """
-    def __init__(self, pattern, gaps=False, flags=regex.UNICODE | regex.MULTILINE | regex.DOTALL | regex.VERSION1):
+    def __init__(self, pattern, gaps=False, flags=regex.UNICODE | regex.MULTILINE | regex.DOTALL):
         # If they gave us a regexp object, extract the pattern.
         pattern = getattr(pattern, 'pattern', pattern)
 
@@ -187,6 +187,28 @@ class WordTokenizer(RegexpTokenizer):
 
     def __init__(self, detect_compound_names=True):
         pattern = self.URL + '|' + self.EMAIL + '|' + self.NUM + '|' + self.CONTRACTION + '|' + self.WORD
+        if detect_compound_names:
+            pattern = self.NAME_COMPOUND + '|' + pattern
+
+        RegexpTokenizer.__init__(self, pattern, gaps=False)
+
+
+class SimpleWordTokenizer(RegexpTokenizer):
+    """
+    Tokenize a string into words using a set of very simple rules.
+
+    This :class:`RegexpTokenizer` contains very little special logic. It will:
+      * split token on whitespace;
+      * return compound names as a single token;
+
+    """
+    # Capture multi-term names (optionally with 'of' as the second term).
+    # We exclude [The, But] from the beginning of multi-term names.
+    NAME_COMPOUND = u"((?!(The|But))([A-Z][a-z]+|[A-Z][a-z]{0,2}\.)([^\S\n]of)?([^\S\n][A-Z]+[A-Za-z]+)+)"
+    WORD = u"\S+"
+
+    def __init__(self, detect_compound_names=True):
+        pattern = self.WORD
         if detect_compound_names:
             pattern = self.NAME_COMPOUND + '|' + pattern
 

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1445,7 +1445,7 @@ def find_bi_gram_words(frames, min_bi_gram_freq=3, min_bi_gram_coverage=0.65):
             for token_list in bi_gram_analyser.analyse(sentence):
                 # Using a special filter that returns list of tokens. List of 1 means no bi-grams.
                 if len(token_list) > 1:  # We have a bi-gram people!
-                    candidate_bi_grams.inc("{} {}".format(token_list[0].value, token_list[1].value))
+                    candidate_bi_grams.inc(u"{} {}".format(token_list[0].value, token_list[1].value))
                 for t in token_list:  # Keep a list of terms we have seen so we can record freqs later.
                     if not t.stopped:  # Naughty stopwords!
                         terms_seen.add(t.value)
@@ -1454,8 +1454,8 @@ def find_bi_gram_words(frames, min_bi_gram_freq=3, min_bi_gram_coverage=0.65):
 
     # Filter and sort by frequency-decreasing
     candidate_bi_gram_list = filter(lambda (k, v): v > min_bi_gram_freq, candidate_bi_grams.iteritems())
-    candidate_bi_gram_list = filter(lambda (k, v): v / uni_gram_frequencies[k.split(" ")[0]] > min_bi_gram_coverage
-                                    and v / uni_gram_frequencies[k.split(" ")[1]] > min_bi_gram_coverage,
+    candidate_bi_gram_list = filter(lambda (k, v): v / uni_gram_frequencies[k.split(" ")[0]] > min_bi_gram_coverage and
+                                    v / uni_gram_frequencies[k.split(" ")[1]] > min_bi_gram_coverage,
                                     candidate_bi_gram_list)
     logger.debug("Identified {} n-grams.".format(len(candidate_bi_gram_list)))
 

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -4,12 +4,11 @@
 import os
 
 from caterpillar import abstract_method_tester
-from caterpillar.processing.analysis import stopwords
-from caterpillar.processing.analysis.analyse import DefaultAnalyser
 from caterpillar.processing.index import IndexConfig, IndexWriter, IndexReader
 from caterpillar.processing.plugin import AnalyticsPlugin
 from caterpillar.processing import schema
 from caterpillar.storage.sqlite import SqliteStorage
+from caterpillar.test_util import TestAnalyser
 
 
 class TrivialTestPlugin(AnalyticsPlugin):
@@ -30,7 +29,7 @@ class TrivialTestPlugin(AnalyticsPlugin):
 def test_plugin(index_dir):
     with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'rbU') as f:
         data = f.read()
-        analyser = DefaultAnalyser(stopword_list=stopwords.ENGLISH_TEST)
+        analyser = TestAnalyser()
         with IndexWriter(index_dir, IndexConfig(SqliteStorage, schema.Schema(text=schema.TEXT(analyser=analyser)))) as \
                 writer:
             writer.add_document(text=data, frame_size=2)

--- a/caterpillar/processing/test/test_schema.py
+++ b/caterpillar/processing/test/test_schema.py
@@ -10,14 +10,15 @@ from caterpillar.storage.sqlite import SqliteStorage
 import pytest
 
 from caterpillar.processing import schema
-from caterpillar.processing.analysis import stopwords
-from caterpillar.processing.analysis.analyse import DefaultAnalyser
 from caterpillar.processing.index import IndexWriter, IndexReader, IndexConfig
 from caterpillar.processing.schema import BOOLEAN, FieldType, ID, NUMERIC, Schema, TEXT, FieldConfigurationError
 from caterpillar.searching.query.querystring import QueryStringQuery
 
 
 # Plumbing tests
+from caterpillar.test_util import TestAnalyser
+
+
 def test_schema():
     simple_schema = Schema(test=TEXT, user=ID)
     names = simple_schema.names()
@@ -136,7 +137,7 @@ def test_index_stored_fields():
     path = tempfile.mkdtemp()
     try:
         tmp_dir = os.path.join(path, "tmp")
-        analyser = DefaultAnalyser(stopword_list=stopwords.ENGLISH_TEST)
+        analyser = TestAnalyser()
         with IndexWriter(tmp_dir, IndexConfig(SqliteStorage,
                                               Schema(text=TEXT(analyser=analyser, stored=False),
                                                      test=NUMERIC(stored=True),

--- a/caterpillar/searching/query/querystring.py
+++ b/caterpillar/searching/query/querystring.py
@@ -137,12 +137,12 @@ class _QueryStringParser(object):
         #
         wildcard = False
         if '?' in field_value:
-            # Insert regex pattern for single character wildcard
-            field_value = field_value.replace('?', r'\w')
+            # Insert regex pattern for single character wildcard (ie not a white-space char).
+            field_value = field_value.replace('?', r'\S')
             wildcard = True
         if '*' in field_value:
             # Insert regex pattern for multiple character wildcard
-            field_value = field_value.replace('*', r'[\w]*')
+            field_value = field_value.replace('*', r'[\S]*')
             wildcard = True
 
         # Determine matching frames
@@ -192,11 +192,11 @@ class _QueryStringParser(object):
             wildcard = False
             if '?' in value:
                 # Insert regex pattern for single character wildcard
-                value = value.replace('?', r'\w')
+                value = value.replace('?', r'\S')
                 wildcard = True
             if '*' in value:
                 # Insert regex pattern for multiple character wildcard
-                value = value.replace('*', r'[\w]*')
+                value = value.replace('*', r'[\S]*')
                 wildcard = True
             if wildcard:
                 re = regex.compile('^' + value + '$')

--- a/caterpillar/test_util.py
+++ b/caterpillar/test_util.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2012-2015 Kapiche Ltd.
+# Author: Ryan Stuart<ryan@kapiche.com>
+from caterpillar.processing.analysis import stopwords
+from caterpillar.processing.analysis.analyse import Analyser
+from caterpillar.processing.analysis.filter import OuterPunctuationFilter, StopFilter, PositionalLowercaseWordFilter, \
+    BiGramFilter
+from caterpillar.processing.analysis.filter import PossessiveContractionFilter
+from caterpillar.processing.analysis.tokenize import SimpleWordTokenizer
+
+
+class TestAnalyser(Analyser):
+    _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
+
+    def __init__(self, stopword_list=None):
+        super(TestAnalyser, self).__init__()
+        if stopword_list is None:
+            stopword_list = stopwords.ENGLISH_TEST
+
+        self._filters = [
+            OuterPunctuationFilter(leading_allow=['@', '#']),
+            PossessiveContractionFilter(),
+            StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
+            PositionalLowercaseWordFilter(0),
+        ]
+
+    def get_tokenizer(self):
+        return self._tokenizer
+
+    def get_filters(self):
+        return self._filters
+
+
+class TestBiGramAnalyser(Analyser):
+    _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
+
+    def __init__(self, bi_grams, stopword_list=None):
+        if stopword_list is None:
+            stopword_list = stopwords.ENGLISH_TEST
+        self._filters = [
+            OuterPunctuationFilter(leading_allow=['@', '#']),
+            PossessiveContractionFilter(),
+            StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
+            PositionalLowercaseWordFilter(0),
+            BiGramFilter(bi_grams),
+        ]
+
+    def get_tokenizer(self):
+        return self._tokenizer
+
+    def get_filters(self):
+        return self._filters

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         'caterpillar.storage',
     ],
     package_data={
-        'caterpillar': ['resources/*.txt'],
+        'caterpillar': ['resources/*.txt', 'VERSION'],
     },
     url='https://github.com/Kapiche/caterpillar',
     license='AGPLv3+',


### PR DESCRIPTION
Tokenisation of words now defaults to a tokeniser that splits on
whitespace and captures compound names. The default analyser now also
uses a filter that allows certain leading and trailing punctuation and a
filter that removes possessive contractions in a really robust manner.

There were a bunch of changes to test that were really annoying. I've
now created test analyers that should change ever. When new tokenisers
and analysers are added, we should only ahve to add tests to the
test_analyse etc., not adjust all tests. Of the tests that were updated:

* test_index_merge_terms: An instance of party became tea-party
* test_index_moby_case_folding: Multiple cases of terms being joined to
* other terms because of punctuation. For example - 'Flask--good-bye'
* test_searching_reserved_words: Multiple cases of 'and' joined to other
* terms with punctuation
* test_index_alice_bigram_discovery: The two missing bigrams ('beau
  ootiful' and 'guinea pigs') and now single terms joined with 1
* or more '-'.
* test_searching_alice: Two places where a *ing ending term was joined
* to another term with 1 or more '-'.
* test_searching_alice: One case of 'voice' term joined with '-'.
* test_index_alice: All differences in vocab size verified by hand.

Also fixed a small bug with setup.py.