### PR TITLE
Per field index and per field search for frames

### DIFF
--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -372,6 +372,7 @@ class IndexWriter(object):
 
             for text_field_name, field_frames in frames.iteritems():
                 for frame_id, frame in field_frames.iteritems():
+
                     # Positions & frequencies First
                     for term, indices in frame['_positions'].iteritems():
                         frequencies[text_field_name].inc(term)
@@ -393,6 +394,7 @@ class IndexWriter(object):
                                     associations[text_field_name][term].get(other_term, 0) + 1
                             except KeyError:
                                 associations[text_field_name][term] = {other_term: 1}
+
                     # Metadata
                     if frame['_metadata']:
                         for metadata_field_name, values in frame['_metadata'].iteritems():
@@ -407,6 +409,7 @@ class IndexWriter(object):
                                         metadata[metadata_field_name][value] = [frame_id]
                                     except KeyError:
                                         metadata[metadata_field_name] = {value: [frame_id]}
+
                     # Record text field metadata
                     field_name = frame['_field']
                     if field_name is not None:
@@ -424,10 +427,12 @@ class IndexWriter(object):
 
         for text_field in text_fields:
             try:
-                rm_frames[text_field] = {k: json.loads(v) if v else {}
-                                         for k, v in self.__storage.get_container_items(
-                                         IndexWriter.FRAMES_CONTAINER.format(text_field),
-                                         keys=self.__rm_frames[text_field])}
+                rm_frames[text_field] = {
+                    k: json.loads(v) if v else {}
+                    for k, v in self.__storage.get_container_items(
+                        IndexWriter.FRAMES_CONTAINER.format(text_field), keys=self.__rm_frames[text_field]
+                    )
+                }
             except KeyError:
                 rm_frames[text_field] = {}
 
@@ -440,24 +445,37 @@ class IndexWriter(object):
         frequencies_index = {}
 
         for text_field in text_fields:
-            positions_index[text_field] = {k: json.loads(v) if v else {}
-                                           for k, v in self.__storage.get_container_items(
-                                           IndexWriter.POSITIONS_CONTAINER.format(text_field),
-                                           keys=new_positions[text_field].viewkeys() |
-                                           rm_positions[text_field].viewkeys())}
-            assocs_index[text_field] = {k: json.loads(v) if v else {}
-                                        for k, v in self.__storage.get_container_items(
-                IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field),
-                keys=new_positions[text_field].viewkeys() |
-                rm_positions[text_field].viewkeys())}
-            frequencies_index[text_field] = {k: json.loads(v) if v else 0
-                                             for k, v in self.__storage.get_container_items(
-                IndexWriter.FREQUENCIES_CONTAINER.format(text_field),
-                keys=new_positions[text_field].viewkeys() |
-                rm_positions[text_field].viewkeys())}
+            positions_index[text_field] = {
+                k: json.loads(v) if v else {}
+                for k, v in self.__storage.get_container_items(
+                    IndexWriter.POSITIONS_CONTAINER.format(text_field),
+                    keys=new_positions[text_field].viewkeys() | rm_positions[text_field].viewkeys()
+                )
+            }
 
-        metadata_index = {k: json.loads(v) if v else {} for k, v in self.__storage.get_container_items(
-            IndexWriter.METADATA_CONTAINER, new_metadata.viewkeys() | rm_metadata.viewkeys())}
+            assocs_index[text_field] = {
+                k: json.loads(v) if v else {}
+                for k, v in self.__storage.get_container_items(
+                    IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field),
+                    keys=new_positions[text_field].viewkeys() | rm_positions[text_field].viewkeys()
+                )
+            }
+
+            frequencies_index[text_field] = {
+                k: json.loads(v) if v else 0
+                for k, v in self.__storage.get_container_items(
+                    IndexWriter.FREQUENCIES_CONTAINER.format(text_field),
+                    keys=new_positions[text_field].viewkeys() |
+                    rm_positions[text_field].viewkeys()
+                )
+            }
+
+        metadata_index = {
+            k: json.loads(v) if v else {}
+            for k, v in self.__storage.get_container_items(
+                IndexWriter.METADATA_CONTAINER, new_metadata.viewkeys() | rm_metadata.viewkeys()
+            )
+        }
 
         # Keys to remove from each index
         delete_positions_keys = set()
@@ -468,18 +486,23 @@ class IndexWriter(object):
         # Positions
         for text_field in text_fields:
             for term, indices in new_positions[text_field].iteritems():
+
                 for frame_id, index in indices.iteritems():
                     try:
-                        positions_index[text_field][term][frame_id] = positions_index[
-                            text_field][term][frame_id] + index
+                        positions_index[text_field][term][frame_id] = \
+                            positions_index[text_field][term][frame_id] + index
+
                     except KeyError:
                         positions_index[text_field][term][frame_id] = index
+
             for term, indices in rm_positions[text_field].iteritems():
                 for frame_id, index in indices.iteritems():
+
                     for item in index:
                         positions_index[text_field][term][frame_id].remove(item)
                         if not positions_index[text_field][term][frame_id]:
                             del positions_index[text_field][term][frame_id]
+
                     if not positions_index[text_field][term]:  # No items stored?
                         del positions_index[text_field][term]
                         delete_positions_keys.add(term)
@@ -770,10 +793,12 @@ class IndexWriter(object):
             '_id': document_id,
             '_frames': frame_ids  # List of frames for this doc
         }
+
         for field_name, field in schema_fields:
             if field.stored and field_name in fields:
                 # Only record stored fields against the document
                 doc_fields[field_name] = fields[field_name]
+
         self.__new_documents[document_id] = doc_fields
 
         # Flush buffers if needed

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -117,6 +117,7 @@ class IndexConfig(object):
     This class might be extended later to store other things.
 
     """
+
     def __init__(self, storage_cls, schema):
         self._storage_cls = storage_cls
         self._schema = schema
@@ -161,6 +162,7 @@ class IndexConfig(object):
 
 
 class IndexWriter(object):
+
     """
     Write to an existing index or create a new index and write to it.
 
@@ -227,7 +229,7 @@ class IndexWriter(object):
     ASSOCIATIONS_CONTAINER = "associations_{}"
 
     # How much data to buffer before a flush
-    RAM_BUFFER_SIZE = 100*1024*1024  # 100 MB
+    RAM_BUFFER_SIZE = 100 * 1024 * 1024  # 100 MB
 
     # Where is the config?
     CONFIG_FILE = "index.config"
@@ -348,13 +350,13 @@ class IndexWriter(object):
             fields = self.__schema.get_indexed_text_fields()
 
             # Inverted term positions index:: field_name --> {term -> [(start, end,), (star,end,), ...]}
-            positions = {field_name: {} for field_name in fields}  
+            positions = {field_name: {} for field_name in fields}
             # Inverted term co-occurrence index:: field_name --> {term -> other_term -> count
-            associations = {field_name: {} for field_name in fields}    
+            associations = {field_name: {} for field_name in fields}
             # Inverted term frequency index:: field_name --> {term -> count
-            frequencies = {field_name:nltk.probability.FreqDist() for field_name in fields}   
+            frequencies = {field_name: nltk.probability.FreqDist() for field_name in fields}
             # Inverted frame metadata:: field_name -> {field_value -> [frame1, frame2]}
-            metadata = {field_name: {} for field_name in fields}   
+            metadata = {field_name: {} for field_name in fields}
 
             # If there are no new frames, return with empty structures
             if len(frames.keys()) == 0:
@@ -380,7 +382,7 @@ class IndexWriter(object):
                                 continue
                             try:
                                 associations[text_field_name][term][other_term] = \
-                                associations[text_field_name][term].get(other_term, 0) + 1
+                                    associations[text_field_name][term].get(other_term, 0) + 1
                             except KeyError:
                                 associations[text_field_name][term] = {other_term: 1}
                     # Metadata
@@ -414,10 +416,10 @@ class IndexWriter(object):
 
         for text_field in text_fields:
             try:
-                rm_frames[text_field] = {k: json.loads(v) if v else {} 
+                rm_frames[text_field] = {k: json.loads(v) if v else {}
                                          for k, v in self.__storage.get_container_items(
                                          IndexWriter.FRAMES_CONTAINER.format(text_field),
-                                         keys = self.__rm_frames[text_field])} 
+                                         keys=self.__rm_frames[text_field])}
             except KeyError:
                 rm_frames[text_field] = {}
 
@@ -430,21 +432,21 @@ class IndexWriter(object):
         frequencies_index = {}
 
         for text_field in text_fields:
-            positions_index[text_field] = {k: json.loads(v) if v else {} 
+            positions_index[text_field] = {k: json.loads(v) if v else {}
                                            for k, v in self.__storage.get_container_items(
-                                           IndexWriter.POSITIONS_CONTAINER.format(text_field), 
-                                           keys=new_positions[text_field].viewkeys() | 
-                                           rm_positions[text_field].viewkeys())}            
-            assocs_index[text_field] = {k: json.loads(v) if v else {} 
-                                       for k, v in self.__storage.get_container_items(
-                                       IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field), 
-                                       keys=new_positions[text_field].viewkeys() | 
-                                       rm_positions[text_field].viewkeys())}
-            frequencies_index[text_field] = {k: json.loads(v) if v else 0
-                                           for k, v in self.__storage.get_container_items(
-                                           IndexWriter.FREQUENCIES_CONTAINER.format(text_field), 
-                                           keys=new_positions[text_field].viewkeys() | 
+                                           IndexWriter.POSITIONS_CONTAINER.format(text_field),
+                                           keys=new_positions[text_field].viewkeys() |
                                            rm_positions[text_field].viewkeys())}
+            assocs_index[text_field] = {k: json.loads(v) if v else {}
+                                        for k, v in self.__storage.get_container_items(
+                IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field),
+                keys=new_positions[text_field].viewkeys() |
+                rm_positions[text_field].viewkeys())}
+            frequencies_index[text_field] = {k: json.loads(v) if v else 0
+                                             for k, v in self.__storage.get_container_items(
+                IndexWriter.FREQUENCIES_CONTAINER.format(text_field),
+                keys=new_positions[text_field].viewkeys() |
+                rm_positions[text_field].viewkeys())}
 
         metadata_index = {k: json.loads(v) if v else {} for k, v in self.__storage.get_container_items(
             IndexWriter.METADATA_CONTAINER, new_metadata.viewkeys() | rm_metadata.viewkeys())}
@@ -460,7 +462,8 @@ class IndexWriter(object):
             for term, indices in new_positions[text_field].iteritems():
                 for frame_id, index in indices.iteritems():
                     try:
-                        positions_index[text_field][term][frame_id] = positions_index[text_field][term][frame_id] + index
+                        positions_index[text_field][term][frame_id] = positions_index[
+                            text_field][term][frame_id] + index
                     except KeyError:
                         positions_index[text_field][term][frame_id] = index
             for term, indices in rm_positions[text_field].iteritems():
@@ -477,7 +480,8 @@ class IndexWriter(object):
         for text_field in text_fields:
             for term, value in new_associations[text_field].iteritems():
                 for other_term, count in value.iteritems():
-                    assocs_index[text_field][term][other_term] = assocs_index[text_field][term].get(other_term, 0) + count
+                    assocs_index[text_field][term][other_term] = assocs_index[
+                        text_field][term].get(other_term, 0) + count
             for term, value in rm_associations[text_field].iteritems():
                 for other_term, count in value.iteritems():
                     assocs_index[text_field][term][other_term] = assocs_index[text_field][term][other_term] - count
@@ -518,28 +522,35 @@ class IndexWriter(object):
             # Positions
             for key in positions_index[text_field]:
                 positions_index[text_field][key] = json.dumps(positions_index[text_field][key])
-            self.__storage.set_container_items(IndexWriter.POSITIONS_CONTAINER.format(text_field), positions_index[text_field])
-            self.__storage.delete_container_items(IndexWriter.POSITIONS_CONTAINER.format(text_field), delete_positions_keys)
+            self.__storage.set_container_items(
+                IndexWriter.POSITIONS_CONTAINER.format(text_field), positions_index[text_field])
+            self.__storage.delete_container_items(
+                IndexWriter.POSITIONS_CONTAINER.format(text_field), delete_positions_keys)
             # Associations
             for key in assocs_index[text_field]:
                 assocs_index[text_field][key] = json.dumps(assocs_index[text_field][key])
-            self.__storage.set_container_items(IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field), assocs_index[text_field])
-            self.__storage.delete_container_items(IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field), delete_assoc_keys)
+            self.__storage.set_container_items(
+                IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field), assocs_index[text_field])
+            self.__storage.delete_container_items(
+                IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field), delete_assoc_keys)
             # Frequencies
             for key in frequencies_index[text_field]:
                 frequencies_index[text_field][key] = json.dumps(frequencies_index[text_field][key])
-            self.__storage.set_container_items(IndexWriter.FREQUENCIES_CONTAINER.format(text_field), frequencies_index[text_field])
-            self.__storage.delete_container_items(IndexWriter.FREQUENCIES_CONTAINER.format(text_field), delete_frequencies_keys)
+            self.__storage.set_container_items(IndexWriter.FREQUENCIES_CONTAINER.format(
+                text_field), frequencies_index[text_field])
+            self.__storage.delete_container_items(
+                IndexWriter.FREQUENCIES_CONTAINER.format(text_field), delete_frequencies_keys)
             # Frames
             try:
                 self.__storage.set_container_items(IndexWriter.FRAMES_CONTAINER.format(text_field),
-                                               {k: json.dumps(v) for k, v in self.__new_frames[text_field].iteritems()})
+                                                   {k: json.dumps(v) for k, v
+                                                    in self.__new_frames[text_field].iteritems()})
             except KeyError:
                 pass
-            try: 
-                self.__storage.delete_container_items(IndexWriter.FRAMES_CONTAINER.format(text_field), 
+            try:
+                self.__storage.delete_container_items(IndexWriter.FRAMES_CONTAINER.format(text_field),
                                                       self.__rm_frames[text_field])
-            except KeyError: # No frames in that field to delete
+            except KeyError:  # No frames in that field to delete
                 pass
         self.__new_frames = {}
         self.__rm_frames = {}
@@ -630,7 +641,7 @@ class IndexWriter(object):
         # Build the frames by performing required analysis.
         frames = {}  # Frame data:: field_name -> {frame_id -> {key: value}}
         metadata = {}  # Inverted frame metadata:: field_name -> field_value
-        frame_ids = {} # List of frame_id's across all fields.
+        frame_ids = {}  # List of frame_id's across all fields.
 
         # Shell frame includes all non-indexed and categorical fields
         shell_frame = {}
@@ -679,7 +690,8 @@ class IndexWriter(object):
                     # Next we need the sentences grouped by frame
                     if frame_size > 0:
                         sentences = sentence_tokenizer.tokenize(paragraph.value, realign_boundaries=True)
-                        sentences_by_frames = [sentences[i:i+frame_size] for i in xrange(0, len(sentences), frame_size)]
+                        sentences_by_frames = [sentences[i:i + frame_size]
+                                               for i in xrange(0, len(sentences), frame_size)]
                     else:
                         sentences_by_frames = [[paragraph.value]]
                     for sentence_list in sentences_by_frames:
@@ -847,22 +859,22 @@ class IndexWriter(object):
         frequencies_index = {
             k: json.loads(v) if v else 0
             for k, v in self.__storage.get_container_items(IndexWriter.FREQUENCIES_CONTAINER.format(text_field))
-            }
+        }
 
         associations_index = {
             k: json.loads(v) if v else {}
             for k, v in self.__storage.get_container_items(IndexWriter.ASSOCIATIONS_CONTAINER.format(text_field))
-            }
+        }
 
         positions_index = {
             k: json.loads(v) if v else {}
             for k, v in self.__storage.get_container_items(IndexWriter.POSITIONS_CONTAINER.format(text_field))
-            }
+        }
 
         frames = {
             k: json.loads(v)
             for k, v in self.__storage.get_container_items(IndexWriter.FRAMES_CONTAINER.format(text_field))
-            }
+        }
 
         for old_term, new_term in merges:
             logger.debug('Merging {} into {}'.format(old_term, new_term))
@@ -1163,6 +1175,7 @@ class IndexWriter(object):
 
 
 class IndexReader(object):
+
     """
     Read information from an existing index.
 
@@ -1198,6 +1211,7 @@ class IndexReader(object):
     some of it's own caching but that is transparent to us.
 
     """
+
     def __init__(self, path):
         """
         Open a new IndexReader for the index at ``path`` (str).
@@ -1307,7 +1321,8 @@ class IndexReader(object):
 
     def get_term_association(self, term, association, field):
         """Returns a count of term associations between ``term`` (str) and ``association`` (str)."""
-        return json.loads(self.__storage.get_container_item(IndexWriter.ASSOCIATIONS_CONTAINER.format(field), term))[association]
+        return json.loads(self.__storage.get_container_item(IndexWriter.ASSOCIATIONS_CONTAINER.format(field),
+                                                            term))[association]
 
     def get_frequencies(self, field):
         """

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -774,7 +774,12 @@ class IndexWriter(object):
             doc = json.decode(self.__storage.get_container_item(IndexWriter.DOCUMENTS_CONTAINER, d_id))
         except KeyError:
             raise DocumentNotFoundError("No such document {}".format(d_id))
-        self.__rm_frames = doc['_frames']
+
+        for field, frames in doc['_frames'].iteritems():
+            try:
+                self.__rm_frames[field] += frames
+            except KeyError:
+                self.__rm_frames[field] = frames
         self.__rm_documents.add(d_id)
 
     def fold_term_case(self, text_field, merge_threshold=0.7):

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -717,21 +717,6 @@ class IndexWriter(object):
                         frame.update(shell_frame)
                         frames[field_name][frame_id] = frame
 
-        # If someone wants to store something besides text we need to handle it if we want to be a storage engine.
-        # This only applies if we had at least 1 indexed field otherwise the frame can't be retrieved.
-        # If there was at least 1 indexed field then there must be metadata!
-        if frame_count==0 and metadata:
-            frame_id = "{}-{}".format(document_id, frame_count)
-            frame = {
-                '_id': frame_id,
-                '_field': None,  # There is no text field
-                '_positions': {},
-                '_sequence_number': frame_count,
-                '_doc_id': document_id,
-            }
-            frame.update(shell_frame)
-            frames[frame_id] = frame
-
         # Store the complete metadata in each item
         for field_name, values in frames.iteritems():
             for f_id in values:
@@ -1359,7 +1344,7 @@ class IndexReader(object):
 
     def get_frames(self, field, frame_ids=None,):
         """
-        Generator across frames from this index.
+        Generator across frames from this field in this index.
 
         If present, the returned frames will be restricted to those with ids in ``frame_ids`` (list). Format of the
         frames index data is as follows::

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -426,15 +426,12 @@ class IndexWriter(object):
 
         # Remember to include the '' field for metadata only surrogate frames.
         for field in self.__rm_frames.keys():
-            try:
-                rm_frames[field] = {
-                    k: json.loads(v) if v else {}
-                    for k, v in self.__storage.get_container_items(
-                        IndexWriter.FRAMES_CONTAINER.format(field), keys=self.__rm_frames[field]
-                    )
-                }
-            except KeyError:
-                rm_frames[field] = {}
+            rm_frames[field] = {
+                k: json.loads(v) if v else {}
+                for k, v in self.__storage.get_container_items(
+                    IndexWriter.FRAMES_CONTAINER.format(field), keys=self.__rm_frames[field]
+                )
+            }
 
         new_positions, new_associations, new_frequencies, new_metadata = index_frames(self.__new_frames)
         rm_positions, rm_associations, rm_frequencies, rm_metadata = index_frames(rm_frames)
@@ -575,19 +572,16 @@ class IndexWriter(object):
         # Use the actual fields for adding the frames - to handle the surrogate frames created when no
         # text field is present.
         for field in self.__new_frames.keys():
-            try:
-                self.__storage.set_container_items(IndexWriter.FRAMES_CONTAINER.format(field),
-                                                   {k: json.dumps(v) for k, v
-                                                    in self.__new_frames[field].iteritems()})
-            except KeyError:
-                pass
+            self.__storage.set_container_items(
+                IndexWriter.FRAMES_CONTAINER.format(field), {
+                    k: json.dumps(v) for k, v in self.__new_frames[field].iteritems()
+                }
+            )
 
         for field in self.__rm_frames.keys():
-            try:
-                self.__storage.delete_container_items(IndexWriter.FRAMES_CONTAINER.format(field),
-                                                      self.__rm_frames[field])
-            except KeyError:  # No frames in that field to delete
-                pass
+            self.__storage.delete_container_items(
+                IndexWriter.FRAMES_CONTAINER.format(field), self.__rm_frames[field]
+            )
 
         self.__new_frames = {}
         self.__rm_frames = {}

--- a/caterpillar/processing/schema.py
+++ b/caterpillar/processing/schema.py
@@ -255,6 +255,10 @@ class Schema(object):
         """Returns a list of the names of the fields in this schema."""
         return sorted(self._fields.keys())
 
+    def get_indexed_text_fields(self):
+        """Returns a list of the indexed text fields."""
+        return [name for name, field in self._fields.iteritems() if field._indexed and type(field) == TEXT]
+
     def add(self, name, field_type):
         """
         Adds a field to this schema.

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -23,16 +23,36 @@ def test_index_open(index_dir):
         data = f.read()
         analyser = TestAnalyser()
         writer = IndexWriter(index_dir, IndexConfig(SqliteStorage,
-                             Schema(text=TEXT(analyser=analyser), document=TEXT(analyser=analyser, indexed=False),
-                                    flag=FieldType(analyser=EverythingAnalyser(), indexed=True, categorical=True))))
+                             Schema(text1=TEXT(analyser=analyser), 
+                                    text2=TEXT(analyser=analyser),
+                                    document=TEXT(analyser=analyser, indexed=False),
+                                    flag=FieldType(analyser=EverythingAnalyser(), 
+                                    indexed=True, categorical=True))))
         with writer:
-            writer.add_document(text=data, document='alice.txt', flag=True, frame_size=2)
+            writer.add_document(text1=data, text2=data, document='alice.txt', flag=True, frame_size=2)
+
+        # Identical text fields should generate the same frames and frequencies
+        with IndexReader(index_dir) as reader:
+            assert sum(1 for _ in reader.get_frequencies('text1')) == 500
+            assert sum(1 for _ in reader.get_frequencies('text2')) == 500 
+            assert reader.get_term_frequency('Alice', 'text1') == 23
+            assert reader.get_term_frequency('Alice', 'text2') == 23
+            assert reader.get_document_count() == 1
+            assert reader.get_frame_count('text1') == 52
+            assert reader.get_frame_count('text2') == 52
+            assert isinstance(reader.get_schema()['text1'], TEXT)
+            assert isinstance(reader.get_schema()['text2'], TEXT)
+
+        # Adding the same document twice should double the frame, term_frequencies and document counts
+        with writer:
+            writer.add_document(text1=data, text2=data, document='alice.txt', flag=True, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            assert sum(1 for _ in reader.get_frequencies()) == 500
-            assert reader.get_term_frequency('Alice') == 23
-            assert reader.get_document_count() == 1
-            assert isinstance(reader.get_schema()['text'], TEXT)
+            assert sum(1 for _ in reader.get_frequencies('text1')) == 500
+            assert reader.get_term_frequency('Alice', 'text1') == 46
+            assert reader.get_document_count() == 2
+            assert reader.get_frame_count('text1') == 104
+            assert isinstance(reader.get_schema()['text1'], TEXT)
 
         path = tempfile.mkdtemp()
         new_dir = os.path.join(path, "no_reader")
@@ -44,7 +64,7 @@ def test_index_open(index_dir):
                 with IndexWriter(new_dir, IndexConfig(SqliteStorage, Schema(text=TEXT))) as writer:
                     pass
                 os.remove(os.path.join(new_dir, "storage.db"))
-                IndexReader(new_dir)  # begin() was never called on the writer
+                IndexReader(new_dir)  # The written container no longer exists
         finally:
             shutil.rmtree(path)
 
@@ -99,14 +119,15 @@ def test_index_alice(index_dir):
                                          ref=123, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            assert sum(1 for _ in reader.get_term_positions('nice')) == 3
-            assert sum(1 for _ in reader.get_term_positions('key')) == 5
+            x = reader.get_term_positions('nice', 'text')
+            assert sum(1 for _ in reader.get_term_positions('nice', 'text')) == 3
+            assert sum(1 for _ in reader.get_term_positions('key', 'text')) == 5
 
-            assert reader.get_term_association('Alice', 'poor') == reader.get_term_association('poor', 'Alice') == 3
-            assert reader.get_term_association('key', 'golden') == reader.get_term_association('golden', 'key') == 3
+            assert reader.get_term_association('Alice', 'poor', 'text') == reader.get_term_association('poor', 'Alice', 'text') == 3
+            assert reader.get_term_association('key', 'golden', 'text') == reader.get_term_association('golden', 'key', 'text') == 3
 
-            assert reader.get_vocab_size() == sum(1 for _ in reader.get_frequencies()) == 500
-            assert reader.get_term_frequency('Alice') == 23
+            assert reader.get_vocab_size('text') == sum(1 for _ in reader.get_frequencies('text')) == 500
+            assert reader.get_term_frequency('Alice', 'text') == 23
 
             # Make sure this works
             reader.__sizeof__()
@@ -120,13 +141,6 @@ def test_index_alice(index_dir):
             assert 'field2' in schema
 
         with IndexWriter(index_dir) as writer:
-            schema.add('testadd', TEXT)
-            writer.set_schema(schema)
-
-        with IndexReader(index_dir) as reader:
-            assert 'testadd' in reader.get_schema()
-
-        with IndexWriter(index_dir) as writer:
             writer.delete_document(doc_id)
 
         with IndexReader(index_dir) as reader:
@@ -138,9 +152,9 @@ def test_index_alice(index_dir):
                 writer.delete_document(doc_id)
 
         with IndexReader(index_dir) as reader:
-            assert 'Alice' not in reader.get_frequencies()
-            assert 'Alice' not in reader.get_associations_index()
-            assert 'Alice' not in reader.get_positions_index()
+            assert 'Alice' not in reader.get_frequencies('text')
+            assert 'Alice' not in reader.get_associations_index('text')
+            assert 'Alice' not in reader.get_positions_index('text')
 
         # Test not text
         with IndexWriter(index_dir) as writer:
@@ -153,7 +167,7 @@ def test_index_alice(index_dir):
             writer.add_document(text=unicode("unicode data"), document='test', frame_size=0)
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_frame_count() == 2
+            assert reader.get_frame_count('text') == 2
 
 
 def test_index_writer_rollback(index_dir):
@@ -202,10 +216,10 @@ def test_index_frames_docs_alice(index_dir):
             writer.add_document(text=data, document='alice.txt', frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_frame_count() == 52
+            assert reader.get_frame_count('text') == 52
 
-            frame_id = reader.get_term_positions('Alice').keys()[0]
-            assert frame_id == reader.get_frame(frame_id)['_id']
+            frame_id = reader.get_term_positions('Alice', 'text').keys()[0]
+            assert frame_id == reader.get_frame(frame_id, 'text')['_id']
 
             doc_id = frame_id.split('-')[0]
             assert doc_id == reader.get_document(doc_id)['_id']
@@ -221,9 +235,9 @@ def test_index_moby_small(index_dir):
             writer.add_document(text=data, frame_size=2, )
 
         with IndexReader(index_dir) as reader:
-            assert sum(1 for _ in reader.get_term_positions('Mr. Chace')) == 1
-            assert sum(1 for _ in reader.get_term_positions('CONVERSATIONS')) == 1
-            assert sum(1 for _ in reader.get_frequencies()) == 38
+            assert sum(1 for _ in reader.get_term_positions('Mr. Chace', 'text')) == 1
+            assert sum(1 for _ in reader.get_term_positions('CONVERSATIONS', 'text')) == 1
+            assert sum(1 for _ in reader.get_frequencies('text')) == 38
 
 
 def test_index_alice_bigram_discovery(index_dir):
@@ -233,7 +247,7 @@ def test_index_alice_bigram_discovery(index_dir):
             writer.add_document(text=data, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames())
+            bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 4
             assert 'golden key' in bi_grams
 
@@ -245,7 +259,7 @@ def test_moby_bigram_discovery(index_dir):
             writer.add_document(text=data, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames())
+            bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 10
             assert 'steering oar' in bi_grams
 
@@ -257,7 +271,7 @@ def test_wikileaks_bigram_discovery(index_dir):
             writer.add_document(text=data, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames())
+            bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 29
 
 
@@ -268,7 +282,7 @@ def test_employee_survet_bigram_discovery(index_dir):
             writer.add_document(text=data, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames())
+            bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 7
 
 
@@ -279,7 +293,7 @@ def test_index_alice_merge_bigram(index_dir):
         with IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT))) as writer:
             writer.add_document(text=data)
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames(), min_count=3)
+            bi_grams = find_bi_gram_words(reader.get_frames('text'), min_count=3)
 
         bigram_index = os.path.join(tempfile.mkdtemp(), "bigram")
         merge_index = os.path.join(tempfile.mkdtemp(), "merge")
@@ -291,63 +305,66 @@ def test_index_alice_merge_bigram(index_dir):
                 with pytest.raises(ValueError):
                     writer._merge_terms_into_ngram("old", None, {}, {}, {}, {})
 
-            merges = [[b.split(' '), b] for b in bi_grams]
+            terms_to_merge = [[b.split(' '), b] for b in bi_grams]
 
             # Potential bi-grams 'white kid' & 'kid gloves' form the tri-gram 'white kid gloves'.
             # The bi-gram analyser will match 'white kid' first due to lexical order, consuming the 'kid' token.
-            # Subsequently, 'kid gloves' will not be matched. This manual test using `merge_terms` however, attempts
+            # Subsequently, 'kid gloves' will not be matched. This manual test using `terms_to_merge` however, attempts
             # to convert the bi-grams in alphabetic order, hence 'kid gloves' will be matched first.
-            for i, m in enumerate(merges):
+            for i, m in enumerate(terms_to_merge):
                 if m[1] == 'kid gloves':
                     break
             # ...so, here we just re-order 'kid gloves' to the end of `merges`
             # to emulate the behavior of the bi-gram analyser
-            merges.append(merges.pop(i))
+            terms_to_merge.append(terms_to_merge.pop(i))
 
             analyser = TestAnalyser()
             with IndexWriter(merge_index, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser)))) as writer:
                 writer.add_document(text=data)
-                writer.merge_terms(merges)
+                writer.merge_terms(terms_to_merge, 'text')
 
             # Verify indexes match
             with IndexReader(merge_index) as merges, IndexReader(bigram_index) as bigrams:
                 # Frequencies
-                assert bigrams.get_term_frequency('golden key') == 6
-                assert bigrams.get_term_frequency('golden') == 1
-                assert bigrams.get_term_frequency('key') == 3
-                merge_frequencies = {k: v for k, v in merges.get_frequencies()}
-                for term, frequency in bigrams.get_frequencies():
+                assert bigrams.get_term_frequency('golden key', 'text') == 6
+                assert bigrams.get_term_frequency('golden', 'text') == 1
+                assert bigrams.get_term_frequency('key', 'text') == 3
+                merge_frequencies = {k: v for k, v in merges.get_frequencies('text')}
+                bigram_frequencies = {k: v for k, v in bigrams.get_frequencies('text')}
+                merge_associations = {k: v for k, v in merges.get_associations_index('text')}
+                bigram_associations = {k: v for k, v in bigrams.get_associations_index('text')}
+                for term, frequency in bigrams.get_frequencies('text'):
                     assert merge_frequencies[term] == frequency
                 # Associations
-                merge_associations = {k: v for k, v in merges.get_associations_index()}
-                for term, associations in bigrams.get_associations_index():
+                merge_associations = {k: v for k, v in merges.get_associations_index('text')}
+                for term, associations in bigrams.get_associations_index('text'):
                     assert merge_associations[term] == associations
                 # Frame positions
                 frame_mappings = {}
-                merge_frames = sorted({k: v for k, v in merges.get_frames()}.values(),
+                merge_frames = sorted({k: v for k, v in merges.get_frames('text')}.values(),
                                       key=lambda t: t['_sequence_number'])
-                bigram_frames = sorted({k: v for k, v in bigrams.get_frames()}.values(),
+                bigram_frames = sorted({k: v for k, v in bigrams.get_frames('text')}.values(),
                                        key=lambda t: t['_sequence_number'])
                 for i, merge_frame in enumerate(merge_frames):
                     frame_mappings[bigram_frames[i]['_id']] = merge_frame['_id']
                     assert merge_frame['_positions'] == bigram_frames[i]['_positions']
                 # Global positions
-                merge_positions = {k: v for k, v in merges.get_positions_index()}
-                for term, positions in bigrams.get_positions_index():
+                merge_positions = {k: v for k, v in merges.get_positions_index('text')}
+                for term, positions in bigrams.get_positions_index('text'):
                     for f_id, f_positions in positions.iteritems():
                         assert f_positions == merge_positions[term][frame_mappings[f_id]]
 
                 with pytest.raises(Exception):
-                    merges.merge_terms([[('hot', 'dog',), '']])
+                    merges.merge_terms([[('hot', 'dog',), '']], 'text')
 
             with IndexWriter(merge_index) as writer:
-                writer.merge_terms([[('garbage', 'term',), 'test']])
-                writer.merge_terms([[('Alice', 'garbage',), 'test']])
+                writer.merge_terms([[('garbage', 'term',), 'test']], 'text')
+                writer.merge_terms([[('Alice', 'garbage',), 'test']], 'text')
             with IndexReader(merge_index) as reader:
                 with pytest.raises(KeyError):
-                    reader.get_term_frequency('garbage term')
+                    reader.get_term_frequency('garbage term', 'text')
                 with pytest.raises(KeyError):
-                    reader.get_term_frequency('Alice garbage')
+                    reader.get_term_frequency('Alice garbage', 'text')
         finally:
             shutil.rmtree(bigram_index)
             shutil.rmtree(merge_index)
@@ -360,33 +377,33 @@ def test_index_moby_case_folding(index_dir):
         writer = IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser))))
         with writer:
             writer.add_document(text=data, frame_size=2)
-            writer.fold_term_case()
+            writer.fold_term_case('text')
 
         with IndexReader(index_dir) as reader:
             with pytest.raises(KeyError):
-                reader.get_term_positions('flask')
+                reader.get_term_positions('flask', 'text')
             with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('flask')
-            assert reader.get_term_frequency('Flask') == 88
-            assert reader.get_term_association('Flask', 'person') == reader.get_term_association('person', 'Flask') == 2
+                assert not reader.get_term_frequency('flask', 'text')
+            assert reader.get_term_frequency('Flask', 'text') == 88
+            assert reader.get_term_association('Flask', 'person', 'text') == reader.get_term_association('person', 'Flask', 'text') == 2
 
             with pytest.raises(KeyError):
-                reader.get_term_positions('Well')
+                reader.get_term_positions('Well', 'text')
             with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('Well')
-            assert reader.get_term_frequency('well') == 194
-            assert reader.get_term_association('well', 'whale') == reader.get_term_association('whale', 'well') == 20
+                assert not reader.get_term_frequency('Well', 'text')
+            assert reader.get_term_frequency('well', 'text') == 194
+            assert reader.get_term_association('well', 'whale', 'text') == reader.get_term_association('whale', 'well', 'text') == 20
 
             with pytest.raises(KeyError):
-                reader.get_term_positions('Whale')
+                reader.get_term_positions('Whale', 'text')
             with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('Whale')
-            assert reader.get_term_frequency('whale') == 695
-            assert reader.get_term_association('whale', 'American') == \
-                reader.get_term_association('American', 'whale') == 9
+                assert not reader.get_term_frequency('Whale', 'text')
+            assert reader.get_term_frequency('whale', 'text') == 695
+            assert reader.get_term_association('whale', 'American', 'text') == \
+                reader.get_term_association('American', 'whale', 'text') == 9
 
-            assert reader.get_term_frequency('T. HERBERT') == 1
-            assert sum(1 for _ in reader.get_frequencies()) == 20542
+            assert reader.get_term_frequency('T. HERBERT', 'text') == 1
+            assert sum(1 for _ in reader.get_frequencies('text')) == 20542
 
 
 def test_index_merge_terms(index_dir):
@@ -399,14 +416,14 @@ def test_index_merge_terms(index_dir):
             writer.add_document(text=data, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_term_frequency('alice') == 86
-            assert reader.get_term_association('alice', 'creatures') == 1
-            assert sum(1 for _ in reader.get_term_positions('alice')) == 86
+            assert reader.get_term_frequency('alice', 'text') == 86
+            assert reader.get_term_association('alice', 'creatures', 'text') == 1
+            assert sum(1 for _ in reader.get_term_positions('alice', 'text')) == 86
 
-            assert reader.get_term_frequency('party') == 8
-            assert reader.get_term_association('party', 'creatures') == 1
-            assert reader.get_term_association('party', 'assembled') == 1
-            assert sum(1 for _ in reader.get_term_positions('party')) == 8
+            assert reader.get_term_frequency('party', 'text') == 8
+            assert reader.get_term_association('party', 'creatures', 'text') == 1
+            assert reader.get_term_association('party', 'assembled', 'text') == 1
+            assert sum(1 for _ in reader.get_term_positions('party', 'text')) == 8
 
         writer = IndexWriter(index_dir)
         with writer:
@@ -415,22 +432,22 @@ def test_index_merge_terms(index_dir):
                 ('alice', 'tplink',),  # rename
                 ('Eaglet', 'party',),  # merge
                 ('idonotexist', '',),  # non-existent term
-            ])
+            ], text_field='text')
 
         with IndexReader(index_dir) as reader:
             with pytest.raises(KeyError):
-                reader.get_term_frequency('Alice')
+                reader.get_term_frequency('Alice', 'text')
             with pytest.raises(KeyError):
-                reader.get_term_positions('Alice')
+                reader.get_term_positions('Alice', 'text')
 
-            assert reader.get_term_frequency('tplink') == 86
-            assert reader.get_term_association('tplink', 'creatures') == 1
-            assert sum(1 for _ in reader.get_term_positions('tplink')) == 86
+            assert reader.get_term_frequency('tplink', 'text') == 86
+            assert reader.get_term_association('tplink', 'creatures', 'text') == 1
+            assert sum(1 for _ in reader.get_term_positions('tplink', 'text')) == 86
 
-            assert reader.get_term_frequency('party') == 10
-            assert reader.get_term_association('party', 'creatures') == 1
-            assert reader.get_term_association('party', 'assembled') == 1
-            assert sum(1 for _ in reader.get_term_positions('party')) == 10
+            assert reader.get_term_frequency('party', 'text') == 10
+            assert reader.get_term_association('party', 'creatures', 'text') == 1
+            assert reader.get_term_association('party', 'assembled', 'text') == 1
+            assert sum(1 for _ in reader.get_term_positions('party', 'text')) == 10
 
 
 def test_index_alice_case_folding(index_dir):
@@ -442,23 +459,23 @@ def test_index_alice_case_folding(index_dir):
                                                            document=TEXT(analyser=analyser, indexed=False))))
         with writer:
             writer.add_document(text=data, document='alice.txt', frame_size=2)
-            writer.fold_term_case()
+            writer.fold_term_case('text')
 
         with IndexReader(index_dir) as reader:
-            positions_index = {k: v for k, v in reader.get_positions_index()}
-            for frame_id, frame in reader.get_frames():
+            positions_index = {k: v for k, v in reader.get_positions_index('text')}
+            for frame_id, frame in reader.get_frames('text'):
                 for term in frame['_positions']:
                     assert frame_id in positions_index[term]
 
             # Check that associations never exceed frequency of either term
-            associations = {k: v for k, v in reader.get_associations_index()}
-            frequencies = {k: v for k, v in reader.get_frequencies()}
+            associations = {k: v for k, v in reader.get_associations_index('text')}
+            frequencies = {k: v for k, v in reader.get_frequencies('text')}
             for term, term_associations in associations.iteritems():
                 for other_term, assoc in term_associations.items():
                     assert assoc <= frequencies[term] and assoc <= frequencies[other_term]
 
             # Check frequencies against positions
-            frequencies = {k: v for k, v in reader.get_frequencies()}
+            frequencies = {k: v for k, v in reader.get_frequencies('text')}
             for term, freq in frequencies.items():
                 assert freq == len(positions_index[term])
 
@@ -478,12 +495,12 @@ def test_index_case_fold_no_new_term(index_dir):
             csv_reader = csv.reader(f)
             for row in csv_reader:
                 writer.add_document(text=row[0])
-            writer.fold_term_case()
+            writer.fold_term_case('text')
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_term_frequency('stirling') == 6
+            assert reader.get_term_frequency('stirling', 'text') == 6
             with pytest.raises(KeyError):
-                reader.get_term_frequency('Stirling')
+                reader.get_term_frequency('Stirling', 'text')
 
 
 def test_index_utf8(index_dir):
@@ -568,8 +585,8 @@ def test_index_reader_writer_isolation(index_dir):
         reader = IndexReader(index_dir)
         reader.begin()
 
-        assert reader.get_frame_count() == 52
-        assert reader.get_term_frequency('Alice') == 23
+        assert reader.get_frame_count('text') == 52
+        assert reader.get_term_frequency('Alice', 'text') == 23
 
         # Add another copy of Alice
         writer = IndexWriter(index_dir, Schema(text=TEXT))
@@ -577,13 +594,13 @@ def test_index_reader_writer_isolation(index_dir):
             writer.add_document(text=data)
 
         # Check reader can't see it
-        assert reader.get_frame_count() == 52
-        assert reader.get_term_frequency('Alice') == 23
+        assert reader.get_frame_count('text') == 52
+        assert reader.get_term_frequency('Alice', 'text') == 23
 
         # Open new reader and make sure it CAN see the changes
         with IndexReader(index_dir) as reader1:
-            assert reader1.get_frame_count() == reader.get_frame_count() * 2
-            assert reader1.get_term_frequency('Alice') == reader.get_term_frequency('Alice') * 2
+            assert reader1.get_frame_count('text') == reader.get_frame_count('text') * 2
+            assert reader1.get_term_frequency('Alice', 'text') == reader.get_term_frequency('Alice', 'text') * 2
 
         reader.close()
 
@@ -597,15 +614,15 @@ def test_index_document_delete(index_dir):
             doc_id = writer.add_document(text=data)
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_frame_count() == 104
-            assert reader.get_term_frequency('Alice') == 46
+            assert reader.get_frame_count('text') == 104
+            assert reader.get_term_frequency('Alice', 'text') == 46
 
         with IndexWriter(index_dir) as writer:
             writer.delete_document(doc_id)
 
         with IndexReader(index_dir) as reader:
-            assert reader.get_frame_count() == 52
-            assert reader.get_term_frequency('Alice') == 23
+            assert reader.get_frame_count('text') == 52
+            assert reader.get_term_frequency('Alice', 'text') == 23
 
 
 def test_index_writer_buffer_flush(index_dir):

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -15,6 +15,7 @@ from caterpillar.storage.sqlite import SqliteStorage
 from caterpillar.processing.analysis.analyse import EverythingAnalyser
 from caterpillar.processing.index import *
 from caterpillar.processing.schema import ID, NUMERIC, TEXT, FieldType, Schema
+from caterpillar.searching.query.querystring import QueryStringQuery
 from caterpillar.test_util import TestAnalyser, TestBiGramAnalyser
 
 
@@ -662,3 +663,14 @@ def test_index_multi_document_delete(index_dir):
         with IndexReader(index_dir) as reader:
             assert reader.get_frame_count('text') == 0
             assert reader.get_document_count() == 0
+
+
+def test_metadata_only_retrieval(index_dir):
+    """Test we can retrieve metadata only documents"""
+    config = IndexConfig(SqliteStorage, schema=Schema(num=NUMERIC(indexed=True)))
+    with IndexWriter(index_dir, config) as writer:
+        writer.add_document(num=1)
+
+    with IndexReader(index_dir) as reader:
+        searcher = reader.searcher()
+        assert searcher.count(QueryStringQuery('num=1')) == 1

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -665,12 +665,19 @@ def test_index_multi_document_delete(index_dir):
             assert reader.get_document_count() == 0
 
 
-def test_metadata_only_retrieval(index_dir):
+def test_metadata_only_retrieval_deletion(index_dir):
     """Test we can retrieve metadata only documents"""
-    config = IndexConfig(SqliteStorage, schema=Schema(num=NUMERIC(indexed=True)))
+    config = IndexConfig(SqliteStorage, schema=Schema(num=NUMERIC(indexed=True), text=TEXT))
     with IndexWriter(index_dir, config) as writer:
-        writer.add_document(num=1)
+        doc_id = writer.add_document(num=1)
 
     with IndexReader(index_dir) as reader:
         searcher = reader.searcher()
         assert searcher.count(QueryStringQuery('num=1')) == 1
+
+    with IndexWriter(index_dir, config) as writer:
+        writer.delete_document(doc_id)
+
+    with IndexReader(index_dir) as reader:
+        assert reader.get_frame_count('') == 0
+        assert reader.get_document_count() == 0

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -23,10 +23,10 @@ def test_index_open(index_dir):
         data = f.read()
         analyser = TestAnalyser()
         writer = IndexWriter(index_dir, IndexConfig(SqliteStorage,
-                             Schema(text1=TEXT(analyser=analyser), 
+                             Schema(text1=TEXT(analyser=analyser),
                                     text2=TEXT(analyser=analyser),
                                     document=TEXT(analyser=analyser, indexed=False),
-                                    flag=FieldType(analyser=EverythingAnalyser(), 
+                                    flag=FieldType(analyser=EverythingAnalyser(),
                                     indexed=True, categorical=True))))
         with writer:
             writer.add_document(text1=data, text2=data, document='alice.txt', flag=True, frame_size=2)
@@ -34,7 +34,7 @@ def test_index_open(index_dir):
         # Identical text fields should generate the same frames and frequencies
         with IndexReader(index_dir) as reader:
             assert sum(1 for _ in reader.get_frequencies('text1')) == 500
-            assert sum(1 for _ in reader.get_frequencies('text2')) == 500 
+            assert sum(1 for _ in reader.get_frequencies('text2')) == 500
             assert reader.get_term_frequency('Alice', 'text1') == 23
             assert reader.get_term_frequency('Alice', 'text2') == 23
             assert reader.get_document_count() == 1
@@ -119,12 +119,13 @@ def test_index_alice(index_dir):
                                          ref=123, frame_size=2)
 
         with IndexReader(index_dir) as reader:
-            x = reader.get_term_positions('nice', 'text')
             assert sum(1 for _ in reader.get_term_positions('nice', 'text')) == 3
             assert sum(1 for _ in reader.get_term_positions('key', 'text')) == 5
 
-            assert reader.get_term_association('Alice', 'poor', 'text') == reader.get_term_association('poor', 'Alice', 'text') == 3
-            assert reader.get_term_association('key', 'golden', 'text') == reader.get_term_association('golden', 'key', 'text') == 3
+            assert reader.get_term_association('Alice', 'poor', 'text') == \
+                reader.get_term_association('poor', 'Alice', 'text') == 3
+            assert reader.get_term_association('key', 'golden', 'text') == \
+                reader.get_term_association('golden', 'key', 'text') == 3
 
             assert reader.get_vocab_size('text') == sum(1 for _ in reader.get_frequencies('text')) == 500
             assert reader.get_term_frequency('Alice', 'text') == 23
@@ -330,9 +331,7 @@ def test_index_alice_merge_bigram(index_dir):
                 assert bigrams.get_term_frequency('golden', 'text') == 1
                 assert bigrams.get_term_frequency('key', 'text') == 3
                 merge_frequencies = {k: v for k, v in merges.get_frequencies('text')}
-                bigram_frequencies = {k: v for k, v in bigrams.get_frequencies('text')}
                 merge_associations = {k: v for k, v in merges.get_associations_index('text')}
-                bigram_associations = {k: v for k, v in bigrams.get_associations_index('text')}
                 for term, frequency in bigrams.get_frequencies('text'):
                     assert merge_frequencies[term] == frequency
                 # Associations
@@ -385,14 +384,16 @@ def test_index_moby_case_folding(index_dir):
             with pytest.raises(KeyError):
                 assert not reader.get_term_frequency('flask', 'text')
             assert reader.get_term_frequency('Flask', 'text') == 88
-            assert reader.get_term_association('Flask', 'person', 'text') == reader.get_term_association('person', 'Flask', 'text') == 2
+            assert reader.get_term_association('Flask', 'person', 'text') == \
+                reader.get_term_association('person', 'Flask', 'text') == 2
 
             with pytest.raises(KeyError):
                 reader.get_term_positions('Well', 'text')
             with pytest.raises(KeyError):
                 assert not reader.get_term_frequency('Well', 'text')
             assert reader.get_term_frequency('well', 'text') == 194
-            assert reader.get_term_association('well', 'whale', 'text') == reader.get_term_association('whale', 'well', 'text') == 20
+            assert reader.get_term_association('well', 'whale', 'text') == \
+                reader.get_term_association('whale', 'well', 'text') == 20
 
             with pytest.raises(KeyError):
                 reader.get_term_positions('Whale', 'text')

--- a/caterpillar/processing/test/test_schema.py
+++ b/caterpillar/processing/test/test_schema.py
@@ -143,7 +143,7 @@ def test_index_stored_fields():
                                                      test=NUMERIC(stored=True),
                                                      test2=BOOLEAN(stored=False)))) as writer:
             doc_id = writer.add_document(text="hello world", test=777, test2=True,
-                                         frame_size=2, fold_case=False, update_index=True)
+                                         frame_size=2)
 
         with IndexReader(tmp_dir) as reader:
             searcher = reader.searcher()

--- a/caterpillar/processing/test/test_schema.py
+++ b/caterpillar/processing/test/test_schema.py
@@ -147,7 +147,7 @@ def test_index_stored_fields():
 
         with IndexReader(tmp_dir) as reader:
             searcher = reader.searcher()
-            hit = searcher.search(QueryStringQuery("*"), limit=1)[0]
+            hit = searcher.search(QueryStringQuery("*", 'text'), limit=1)[0]
             assert 'text' not in hit.data
             assert 'test2' not in hit.data
             assert hit.data['test'] == 777

--- a/caterpillar/searching/__init__.py
+++ b/caterpillar/searching/__init__.py
@@ -32,7 +32,7 @@ class IndexSearcher(object):
 
     def filter(self, query):
         """
-        Return a list of (frame_id, field) pairs for frames that match the specified ``query`` (must be of type
+        Return a list of (field, frame_id) pairs for frames that match the specified ``query`` (must be of type
         `BaseQuery <caterpillar.searching.query.BaseQuery>`_).
 
         """

--- a/caterpillar/searching/__init__.py
+++ b/caterpillar/searching/__init__.py
@@ -20,7 +20,7 @@ class IndexSearcher(object):
     """
     def __init__(self, index_reader, scorer_cls=TfidfScorer):
         self.index_reader = index_reader
-        self.scorer = scorer_cls(index_reader)
+        self.scorer = scorer_cls
 
     def count(self, query):
         """
@@ -49,11 +49,12 @@ class IndexSearcher(object):
         ``start`` and ``limit`` define pagination of results, which defaults to the first 25 frames.
 
         """
+        query_scorer = self.scorer(self.index_reader, query.text_field)
         query_result = self._do_query(query)
-        hits = [SearchHit(fid, self.index_reader.get_frame(fid)) for fid in query_result.frame_ids]
+        hits = [SearchHit(fid, self.index_reader.get_frame(fid, query.text_field)) for fid in query_result.frame_ids]
         num_matches = len(hits)
         if num_matches > 0:
-            hits = self.scorer.score_and_rank(hits, query_result.term_weights)[start:]
+            hits = query_scorer.score_and_rank(hits, query_result.term_weights)[start:]
 
         if limit:
             hits = hits[:limit]

--- a/caterpillar/searching/query/__init__.py
+++ b/caterpillar/searching/query/__init__.py
@@ -16,10 +16,11 @@ class QueryResult(object):
 
     The result of a query is a dict of text_field: set(frame_ids) and text_field: term_weights.
 
-    All term weightings default to 1 unless they are modified explicitly by the query. Their purpose is to facilitate 
+    All term weightings default to 1 unless they are modified explicitly by the query. Their purpose is to facilitate
     scoring a query result, based on the query that returned it.
 
     """
+
     def __init__(self, frame_ids, term_weights, text_field):
         self.frame_ids = {text_field: set(frame_ids)}
         self.term_weights = {text_field: term_weights}
@@ -44,7 +45,6 @@ class QueryResult(object):
                         self.term_weights[text_field] = {term: weight}
         return self
 
-
     def __iand__(self, other_query):
         """ Intersection of this query and other_query. """
 
@@ -60,7 +60,6 @@ class QueryResult(object):
                 self.frame_ids[text_field] &= frame_ids
             except KeyError:
                 self.frame_ids[text_field] = set()
-
 
         for text_field, term_weights in other_query.term_weights.iteritems():
             for term, weight in term_weights.iteritems():
@@ -84,7 +83,6 @@ class QueryResult(object):
                 pass
         # Exclusions are treated as boolean only, and do not affect term weighting for scoring.
         return self
-
 
 
 class QueryError(Exception):

--- a/caterpillar/searching/query/match.py
+++ b/caterpillar/searching/query/match.py
@@ -11,7 +11,7 @@ Callers should use either :class:`MatchAllQuery`` or :class:`MatchSomeQuery` to 
 Also note that it is possible to nest ``MatchAllQuery`` and ``MatchSomeQuery`` objects within themselves and each other.
 
 """
-from caterpillar.searching.query import BaseQuery, QueryResult, QueryError
+from caterpillar.searching.query import BaseQuery
 
 
 class _MatchQuery(BaseQuery):
@@ -32,7 +32,7 @@ class _MatchQuery(BaseQuery):
         self.exclude_queries = exclude_queries
 
     def evaluate(self, index):
-        """Evaluate all queries and combine the results into a single query. 
+        """Evaluate all queries and combine the results into a single query.
 
         """
         results = (q.evaluate(index) for q in self.queries)

--- a/caterpillar/searching/query/querystring.py
+++ b/caterpillar/searching/query/querystring.py
@@ -35,19 +35,19 @@ class QueryStringQuery(BaseQuery):
     Optionally restricts query to the specified ``text_field``.
 
     """
-    def __init__(self, query_str, text_field=None):
+    def __init__(self, query_str, text_field):
         self.query_str = query_str
         self.text_field = text_field
 
     def evaluate(self, index_reader):
-        frame_ids, term_weights = _QueryStringParser(index_reader).parse_and_evaluate(self.query_str)
-        if self.text_field is not None:
-            # Restrict for text field
-            metadata = {k: v for k, v in index_reader.get_metadata()}
-            if self.text_field not in metadata:
-                raise QueryError("Specified text field {} doesn't exist".format(self.text_field))
-            frame_ids.intersection_update(set(metadata[self.text_field]['_text']))
+        metadata = {k: v for k, v in index_reader.get_metadata()}
+        if self.text_field not in metadata:
+            raise QueryError("Specified text field {} doesn't exist".format(self.text_field))
 
+        frame_ids, term_weights = _QueryStringParser(index_reader, self.text_field, metadata).parse_and_evaluate(self.query_str)
+        # Ensure that only frames of the specified text_field are included.
+        # Metadata only queries might return frames for other text fields.
+        frame_ids.intersection_update(set(metadata[self.text_field]['_text']))
         return QueryResult(frame_ids, term_weights)
 
 
@@ -56,11 +56,12 @@ class _QueryStringParser(object):
     This class parses and evaluates query strings against a specified ``index``.
 
     """
-    def __init__(self, index):
+    def __init__(self, index, text_field, metadata):
         self.index = index
         self.schema = index.get_schema()
-        self.metadata = {k: v for k, v in index.get_metadata()}
-        self.terms = [term for term, count in index.get_frequencies()]
+        self.metadata = metadata
+        self.terms = [term for term, count in index.get_frequencies(text_field)]
+        self.text_field = text_field
 
     def __call__(self, node):
         """
@@ -187,7 +188,7 @@ class _QueryStringParser(object):
         value = self._extract_term_value(node)
         if value == '*':
             # Single wildcard matches all frames
-            node.frame_ids = set(self.index.get_frame_ids())
+            node.frame_ids = set(self.index.get_frame_ids(self.text_field))
         else:
             wildcard = False
             if '?' in value:
@@ -203,11 +204,11 @@ class _QueryStringParser(object):
                 for term in self.terms:
                     # Search for terms that match wildcard query
                     if re.match(term):
-                        node.frame_ids.update(set(self.index.get_term_positions(term).keys()))
+                        node.frame_ids.update(set(self.index.get_term_positions(term, self.text_field).keys()))
                         node.matched_terms.add(term)
             else:
                 try:
-                    node.frame_ids.update(set(self.index.get_term_positions(value).keys()))
+                    node.frame_ids.update(set(self.index.get_term_positions(value, self.text_field).keys()))
                     node.matched_terms.add(value)
                 except KeyError:
                     # Term not matched in index

--- a/caterpillar/searching/query/querystring.py
+++ b/caterpillar/searching/query/querystring.py
@@ -44,7 +44,8 @@ class QueryStringQuery(BaseQuery):
         if self.text_field not in metadata:
             raise QueryError("Specified text field {} doesn't exist".format(self.text_field))
 
-        frame_ids, term_weights = _QueryStringParser(index_reader, self.text_field, metadata).parse_and_evaluate(self.query_str)
+        frame_ids, term_weights = _QueryStringParser(index_reader,
+                                                     self.text_field, metadata).parse_and_evaluate(self.query_str)
         # Ensure that only frames of the specified text_field are included.
         # Metadata only queries might return frames for other text fields.
         frame_ids.intersection_update(set(metadata[self.text_field]['_text']))
@@ -100,7 +101,7 @@ class _QueryStringParser(object):
         """
         try:
             query_tree = _QueryStringGrammar.parse(query, tree_factory=self)
-        except ParseError, e:
+        except ParseError:
             raise QueryError("Invalid query syntax.")
 
         # Only pass on term weights for terms that were a positive match

--- a/caterpillar/searching/query/querystring.py
+++ b/caterpillar/searching/query/querystring.py
@@ -48,7 +48,7 @@ class QueryStringQuery(BaseQuery):
         # Ensure that only frames of the specified text_field are included.
         # Metadata only queries might return frames for other text fields.
         frame_ids.intersection_update(set(metadata[self.text_field]['_text']))
-        return QueryResult(frame_ids, term_weights)
+        return QueryResult(frame_ids, term_weights, self.text_field)
 
 
 class _QueryStringParser(object):

--- a/caterpillar/searching/query/test/test_match.py
+++ b/caterpillar/searching/query/test/test_match.py
@@ -10,33 +10,54 @@ class MockTestQuery(BaseQuery):
     A contrived query that simply returns the ``frames`` and ``term_weights`` passed into the ``__init__`` method.
 
     """
-    def __init__(self, frames, term_weights=None):
+    def __init__(self, frames, text_field='text', term_weights=None):
         self.frames = set(frames)
         self.term_weights = term_weights or {}
+        self.text_field = text_field
 
     def evaluate(self, index):
-        return QueryResult(self.frames, self.term_weights)
+        return QueryResult(self.frames, self.term_weights, self.text_field)
 
 
 def test_match_all():
     """Test match all query."""
     # Simple match all
-    r = MatchAllQuery([MockTestQuery([1, 2, 3], {'a': 1}), MockTestQuery([1, 3], {'b': 99})]).evaluate(None)
-    assert r.frame_ids == set([1, 3])
-    assert r.term_weights == {'a': 1, 'b': 99}
+
+    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}), 
+                       MockTestQuery([1, 3], term_weights={'b': 99})]).evaluate(None)
+    assert r.frame_ids['text'] == set([1, 3])
+    assert r.term_weights['text'] == {'a': 1, 'b': 99}
     # Match all with exclude queries
     r = MatchAllQuery([MockTestQuery([1, 2, 3]), MockTestQuery([1, 2, 3])],
                       [MockTestQuery([1]), MockTestQuery([2])]).evaluate(None)
-    assert r.frame_ids == set([3])
+    assert r.frame_ids['text'] == set([3])
+
+    # Match all with exclude queries from different fields.
+    r = MatchAllQuery([MockTestQuery([1, 2, 3]), MockTestQuery([1, 2, 3])],
+                      [MockTestQuery([1],text_field='text2'), MockTestQuery([2])]).evaluate(None)
+    assert r.frame_ids['text'] == set([1, 3])
+
+    # Combining queries on different fields should result in empty sets.
+    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'), 
+                       MockTestQuery([1, 3], term_weights={'b': 99}, text_field='text2')]).evaluate(None)
+    assert r.frame_ids['text1'] == set()     
+    assert r.frame_ids['text2'] == set() 
 
 
 def test_match_some():
     """Test match some query."""
     # Simple match some
-    r = MatchSomeQuery([MockTestQuery([1, 3, 5], {'a': 1}), MockTestQuery([2, 4, 6], {'a': 1.5})]).evaluate(None)
-    assert r.frame_ids == set([1, 2, 3, 4, 5, 6])
-    assert r.term_weights == {'a': 1.5}
+    r = MatchSomeQuery([MockTestQuery([1, 3, 5], term_weights={'a': 1}), 
+                        MockTestQuery([2, 4, 6], term_weights={'a': 1.5})]).evaluate(None)
+    assert r.frame_ids['text'] == set([1, 2, 3, 4, 5, 6])
+    assert r.term_weights['text'] == {'a': 1.5}
     # Match some with exclude queries
     r = MatchSomeQuery([MockTestQuery([1]), MockTestQuery([2]), MockTestQuery([3])],
                        [MockTestQuery([1]), MockTestQuery([2])]).evaluate(None)
-    assert r.frame_ids == set([3])
+    assert r.frame_ids['text'] == set([3])
+
+    # Test with different text_fields in each query.
+    r = MatchSomeQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'), 
+                       MockTestQuery([1, 3], term_weights={'b': 99}, text_field='text2')]).evaluate(None)
+    assert r.frame_ids['text1'] == set([1, 2, 3])     
+    assert r.frame_ids['text2'] == set([1, 3])  

--- a/caterpillar/searching/query/test/test_match.py
+++ b/caterpillar/searching/query/test/test_match.py
@@ -23,7 +23,7 @@ def test_match_all():
     """Test match all query."""
     # Simple match all
 
-    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}), 
+    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}),
                        MockTestQuery([1, 3], term_weights={'b': 99})]).evaluate(None)
     assert r.frame_ids['text'] == set([1, 3])
     assert r.term_weights['text'] == {'a': 1, 'b': 99}
@@ -34,20 +34,20 @@ def test_match_all():
 
     # Match all with exclude queries from different fields.
     r = MatchAllQuery([MockTestQuery([1, 2, 3]), MockTestQuery([1, 2, 3])],
-                      [MockTestQuery([1],text_field='text2'), MockTestQuery([2])]).evaluate(None)
+                      [MockTestQuery([1], text_field='text2'), MockTestQuery([2])]).evaluate(None)
     assert r.frame_ids['text'] == set([1, 3])
 
     # Combining queries on different fields should result in empty sets.
-    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'), 
+    r = MatchAllQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'),
                        MockTestQuery([1, 3], term_weights={'b': 99}, text_field='text2')]).evaluate(None)
-    assert r.frame_ids['text1'] == set()     
-    assert r.frame_ids['text2'] == set() 
+    assert r.frame_ids['text1'] == set()
+    assert r.frame_ids['text2'] == set()
 
 
 def test_match_some():
     """Test match some query."""
     # Simple match some
-    r = MatchSomeQuery([MockTestQuery([1, 3, 5], term_weights={'a': 1}), 
+    r = MatchSomeQuery([MockTestQuery([1, 3, 5], term_weights={'a': 1}),
                         MockTestQuery([2, 4, 6], term_weights={'a': 1.5})]).evaluate(None)
     assert r.frame_ids['text'] == set([1, 2, 3, 4, 5, 6])
     assert r.term_weights['text'] == {'a': 1.5}
@@ -57,7 +57,7 @@ def test_match_some():
     assert r.frame_ids['text'] == set([3])
 
     # Test with different text_fields in each query.
-    r = MatchSomeQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'), 
+    r = MatchSomeQuery([MockTestQuery([1, 2, 3], term_weights={'a': 1}, text_field='text1'),
                        MockTestQuery([1, 3], term_weights={'b': 99}, text_field='text2')]).evaluate(None)
-    assert r.frame_ids['text1'] == set([1, 2, 3])     
-    assert r.frame_ids['text2'] == set([1, 3])  
+    assert r.frame_ids['text1'] == set([1, 2, 3])
+    assert r.frame_ids['text2'] == set([1, 3])

--- a/caterpillar/searching/query/test/test_querystring.py
+++ b/caterpillar/searching/query/test/test_querystring.py
@@ -55,7 +55,7 @@ def test_querystring_query_advanced(index_dir):
     # Metadata
     with IndexReader(index_dir) as reader:
         # Test presence of terms for each text_field
-        # liked:
+        # field: "liked":
         assert len(QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids['liked']) == 1
         assert len(QueryStringQuery('age<80', 'liked').evaluate(reader).frame_ids['liked']) == 3
         assert len(QueryStringQuery('age>=20', 'liked').evaluate(reader).frame_ids['liked']) == 4
@@ -63,7 +63,7 @@ def test_querystring_query_advanced(index_dir):
         assert len(QueryStringQuery('product not gender=*male', 'liked').evaluate(reader).frame_ids['liked']) == 0
         assert 'disliked' not in QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids
 
-        #disliked:
+        # field: "disliked":
         assert len(QueryStringQuery('age=80', 'disliked').evaluate(reader).frame_ids['disliked']) == 1
         assert len(QueryStringQuery('age<80', 'disliked').evaluate(reader).frame_ids['disliked']) == 3
         assert len(QueryStringQuery('age>=20', 'disliked').evaluate(reader).frame_ids['disliked']) == 4
@@ -71,6 +71,7 @@ def test_querystring_query_advanced(index_dir):
         assert len(QueryStringQuery('product not gender=*male', 'disliked').evaluate(reader).frame_ids['disliked']) == 0
         assert 'liked' not in QueryStringQuery('age=80', 'disliked').evaluate(reader).frame_ids
 
-        # Text field
+        # Extras
         assert len(QueryStringQuery('product', 'liked').evaluate(reader).frame_ids['liked']) == 2
-        assert len(QueryStringQuery('gender=female not product', 'disliked').evaluate(reader).frame_ids['disliked']) == 1
+        assert len(QueryStringQuery('gender=female not product',
+                                    'disliked').evaluate(reader).frame_ids['disliked']) == 1

--- a/caterpillar/searching/query/test/test_querystring.py
+++ b/caterpillar/searching/query/test/test_querystring.py
@@ -4,9 +4,12 @@
 import os
 from caterpillar.storage.sqlite import SqliteStorage
 
+import pytest
+
 from caterpillar.processing import schema
 from caterpillar.processing.index import IndexWriter, IndexReader, IndexConfig
 from caterpillar.searching.query.querystring import QueryStringQuery
+from caterpillar.searching.query import QueryError
 
 
 def test_querystring_query_basic(index_dir):
@@ -18,21 +21,24 @@ def test_querystring_query_basic(index_dir):
 
     # Simple terms
     with IndexReader(index_dir) as reader:
-        alice_count = len(QueryStringQuery('Alice', 'text').evaluate(reader).frame_ids)
-        king_count = len(QueryStringQuery('King', 'text').evaluate(reader).frame_ids)
+        alice_count = len(QueryStringQuery('Alice', 'text').evaluate(reader).frame_ids['text'])
+        king_count = len(QueryStringQuery('King', 'text').evaluate(reader).frame_ids['text'])
         assert alice_count > 0
         assert king_count > 0
         # Boolean operators
-        alice_and_king_count = len(QueryStringQuery('Alice AND King', 'text').evaluate(reader).frame_ids)
-        alice_not_king_count = len(QueryStringQuery('Alice NOT King', 'text').evaluate(reader).frame_ids)
-        alice_or_king_count = len(QueryStringQuery('Alice OR King', 'text').evaluate(reader).frame_ids)
-        king_not_alice_count = len(QueryStringQuery('King NOT Alice', 'text').evaluate(reader).frame_ids)
+        alice_and_king_count = len(QueryStringQuery('Alice AND King', 'text').evaluate(reader).frame_ids['text'])
+        alice_not_king_count = len(QueryStringQuery('Alice NOT King', 'text').evaluate(reader).frame_ids['text'])
+        alice_or_king_count = len(QueryStringQuery('Alice OR King', 'text').evaluate(reader).frame_ids['text'])
+        king_not_alice_count = len(QueryStringQuery('King NOT Alice', 'text').evaluate(reader).frame_ids['text'])
         assert alice_not_king_count == alice_count - alice_and_king_count
         assert king_not_alice_count == king_count - alice_and_king_count
         assert alice_or_king_count == alice_not_king_count + king_not_alice_count + alice_and_king_count
         # Wildcards
-        assert len(QueryStringQuery('*ice', 'text').evaluate(reader).frame_ids) > alice_count
-        assert len(QueryStringQuery('K??g', 'text').evaluate(reader).frame_ids) == king_count
+        assert len(QueryStringQuery('*ice', 'text').evaluate(reader).frame_ids['text']) > alice_count
+        assert len(QueryStringQuery('K??g', 'text').evaluate(reader).frame_ids['text']) == king_count
+
+        with pytest.raises(QueryError):
+            QueryStringQuery('Alice', 'not_a_field').evaluate(reader)
 
 
 def test_querystring_query_advanced(index_dir):
@@ -50,19 +56,21 @@ def test_querystring_query_advanced(index_dir):
     with IndexReader(index_dir) as reader:
         # Test presence of terms for each text_field
         # liked:
-        x = QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids
-        assert len(QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids) == 1
-        assert len(QueryStringQuery('age<80', 'liked').evaluate(reader).frame_ids) == 3
-        assert len(QueryStringQuery('age>=20', 'liked').evaluate(reader).frame_ids) == 4
-        assert len(QueryStringQuery('product not gender=male', 'liked').evaluate(reader).frame_ids) == 1
-        assert len(QueryStringQuery('product not gender=*male', 'liked').evaluate(reader).frame_ids) == 0
+        assert len(QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids['liked']) == 1
+        assert len(QueryStringQuery('age<80', 'liked').evaluate(reader).frame_ids['liked']) == 3
+        assert len(QueryStringQuery('age>=20', 'liked').evaluate(reader).frame_ids['liked']) == 4
+        assert len(QueryStringQuery('product not gender=male', 'liked').evaluate(reader).frame_ids['liked']) == 1
+        assert len(QueryStringQuery('product not gender=*male', 'liked').evaluate(reader).frame_ids['liked']) == 0
+        assert 'disliked' not in QueryStringQuery('age=80', 'liked').evaluate(reader).frame_ids
+
         #disliked:
-        assert len(QueryStringQuery('age=80', 'disliked').evaluate(reader).frame_ids) == 1
-        assert len(QueryStringQuery('age<80', 'disliked').evaluate(reader).frame_ids) == 3
-        assert len(QueryStringQuery('age>=20', 'disliked').evaluate(reader).frame_ids) == 4
-        assert len(QueryStringQuery('product not gender=male', 'disliked').evaluate(reader).frame_ids) == 1
-        assert len(QueryStringQuery('product not gender=*male', 'disliked').evaluate(reader).frame_ids) == 0
+        assert len(QueryStringQuery('age=80', 'disliked').evaluate(reader).frame_ids['disliked']) == 1
+        assert len(QueryStringQuery('age<80', 'disliked').evaluate(reader).frame_ids['disliked']) == 3
+        assert len(QueryStringQuery('age>=20', 'disliked').evaluate(reader).frame_ids['disliked']) == 4
+        assert len(QueryStringQuery('product not gender=male', 'disliked').evaluate(reader).frame_ids['disliked']) == 1
+        assert len(QueryStringQuery('product not gender=*male', 'disliked').evaluate(reader).frame_ids['disliked']) == 0
+        assert 'liked' not in QueryStringQuery('age=80', 'disliked').evaluate(reader).frame_ids
 
         # Text field
-        assert len(QueryStringQuery('product', 'liked').evaluate(reader).frame_ids) == 2
-        assert len(QueryStringQuery('gender=female not product', 'disliked').evaluate(reader).frame_ids) == 1
+        assert len(QueryStringQuery('product', 'liked').evaluate(reader).frame_ids['liked']) == 2
+        assert len(QueryStringQuery('gender=female not product', 'disliked').evaluate(reader).frame_ids['disliked']) == 1

--- a/caterpillar/searching/results.py
+++ b/caterpillar/searching/results.py
@@ -8,7 +8,7 @@ class SearchHit(object):
     Represents a single frame that matched the search.
 
     """
-    def __init__(self, frame_id, frame):
+    def __init__(self, frame_id, search_field, frame):
         self.frame_id = frame_id
         self.doc_id = frame['_doc_id']
         self.score = 1
@@ -20,6 +20,7 @@ class SearchHit(object):
         if '_text' in frame:
             self.data[frame['_field']] = frame['_text']  # Make the text available at it's original field name
             self.text_field = frame['_field']
+        self.searched_field = search_field # The searched text field leading to this hit.
 
 
 class SearchResults(list):

--- a/caterpillar/searching/results.py
+++ b/caterpillar/searching/results.py
@@ -20,7 +20,7 @@ class SearchHit(object):
         if '_text' in frame:
             self.data[frame['_field']] = frame['_text']  # Make the text available at it's original field name
             self.text_field = frame['_field']
-        self.searched_field = search_field # The searched text field leading to this hit.
+        self.searched_field = search_field  # The searched text field leading to this hit.
 
 
 class SearchResults(list):

--- a/caterpillar/searching/scoring.py
+++ b/caterpillar/searching/scoring.py
@@ -34,8 +34,9 @@ class TfidfScorer(Scorer):
     Simple tf-idf scorer implementation to be used by ``IndexSearcher``.
 
     """
-    def __init__(self, index):
-        self.num_frames = index.get_frame_count()
+    def __init__(self, index, text_field):
+        self.text_field = text_field
+        self.num_frames = index.get_frame_count(text_field)
         self.index = index
         self.idfs = {}
 

--- a/caterpillar/searching/scoring.py
+++ b/caterpillar/searching/scoring.py
@@ -61,10 +61,10 @@ class TfidfScorer(Scorer):
                     idf = self.idfs[hit.searched_field][term]
                 except KeyError:
                     # calculate & store term's idf
-                    idf =  numpy.log(1 + num_frames / (self.index.get_term_frequency(term, hit.searched_field) + 1))
-                    try: 
+                    idf = numpy.log(1 + num_frames / (self.index.get_term_frequency(term, hit.searched_field) + 1))
+                    try:
                         self.idfs[hit.searched_field][term] = idf
-                    except KeyError: 
+                    except KeyError:
                         self.idfs[hit.searched_field] = {term: idf}
                 score += term_weights[hit.searched_field][term] * tf * idf
             hit.score = score

--- a/caterpillar/searching/test/test_searching.py
+++ b/caterpillar/searching/test/test_searching.py
@@ -47,15 +47,16 @@ def test_searching_alice(index_dir):
             assert searcher.count(QSQ('*ing', 'text')) == 512
             assert searcher.count(QSQ("Alice and (thought or little)", 'text')) == \
                 searcher.count(QSQ("Alice and thought or Alice and little", 'text')) == 95 == \
-                searcher.count(MatchAllQuery([QSQ('Alice', 'text'), MatchSomeQuery([QSQ('thought', 'text'), QSQ('little', 'text')])]))
+                searcher.count(MatchAllQuery([QSQ('Alice', 'text'),
+                               MatchSomeQuery([QSQ('thought', 'text'), QSQ('little', 'text')])]))
             assert searcher.count(QSQ("thistermdoesntexist", 'text')) == 0
             assert searcher.count(QSQ('Mock Turtle', 'text')) == 51
             assert searcher.count(QSQ('*t? R*b??', 'text')) == searcher.count(QSQ('White Rabbit', 'text'))
 
             # Test that filtering, counts and searching all return the same number of results.
             assert searcher.count(QSQ("King", 'text')) == \
-                   len(searcher.filter(QSQ("King", 'text'))) == \
-                   searcher.search(QSQ("King", 'text')).num_matches
+                len(searcher.filter(QSQ("King", 'text'))) == \
+                searcher.search(QSQ("King", 'text')).num_matches
 
             assert "jury" in searcher.search(QSQ("jury", 'text'), limit=1)[0].data['text']
 
@@ -93,7 +94,7 @@ def test_searching_alice(index_dir):
             results = searcher.search(QSQ("King not (court or evidence)", 'text'))
             assert len(results) == 25
             assert len(results.term_weights) == 1
-            assert results.num_matches == 53 == searcher.count(MatchAllQuery([QSQ('King', 'text')], 
+            assert results.num_matches == 53 == searcher.count(MatchAllQuery([QSQ('King', 'text')],
                                                                [QSQ('court or evidence', 'text')]))
             for hit in results:
                 assert "evidence" not in hit.data['text']
@@ -181,7 +182,7 @@ def test_searching_twitter(index_dir):
             assert searcher.count(QSQ('@NYSenate', 'text')) == 1
             assert searcher.count(QSQ('summerdays@gmail.com', 'text')) == 1
             assert searcher.count(QSQ('sentiment=positive', 'text')) + \
-                   searcher.count(QSQ('sentiment=negative', 'text')) == reader.get_frame_count('text')
+                searcher.count(QSQ('sentiment=negative', 'text')) == reader.get_frame_count('text')
 
 
 def test_searching_nps(index_dir):
@@ -225,16 +226,17 @@ def test_searching_nps(index_dir):
 
             # Metadata field searching
             assert searcher.count(QSQ('nps=10 and store=DANNEVIRKE', 'liked')) + \
-                   searcher.count(QSQ('nps=10 and store=DANNEVIRKE', 'disliked')) + \
-                   searcher.count(QSQ('nps=10 and store=DANNEVIRKE', 'would_like')) == 6
+                searcher.count(QSQ('nps=10 and store=DANNEVIRKE', 'disliked')) + \
+                searcher.count(QSQ('nps=10 and store=DANNEVIRKE', 'would_like')) == 6
 
             num_christchurch = searcher.count(QSQ('region=Christchurch', 'liked'))
 
-            num_null_nps_christchurch = num_christchurch - searcher.count(QSQ('region=Christchurch and nps > 0', 'liked'))
+            num_null_nps_christchurch = num_christchurch - searcher.count(QSQ('region=Christchurch and nps > 0',
+                                                                              'liked'))
 
             assert num_christchurch == searcher.count(QSQ('region=Christchurch and nps < 8', 'liked')) + \
-                                       searcher.count(QSQ('region=Christchurch and nps >= 8', 'liked')) + \
-                                       num_null_nps_christchurch
+                searcher.count(QSQ('region=Christchurch and nps >= 8', 'liked')) + \
+                num_null_nps_christchurch
 
             assert searcher.count(QSQ('region=Christchurch and nps>7 and (reliable or quick)', 'disliked')) \
                 == searcher.count(QSQ('region = Christchurch and nps>7', 'disliked')) \
@@ -286,7 +288,8 @@ def test_searching_reserved_words(index_dir):
 
         with IndexReader(index_dir) as reader:
             searcher = reader.searcher()
-            assert searcher.count(QSQ('"and"', 'text')) == sum(1 for _ in reader.get_term_positions('and', 'text')) == 469
+            assert searcher.count(QSQ('"and"', 'text')) == \
+                sum(1 for _ in reader.get_term_positions('and', 'text')) == 469
             assert searcher.count(QSQ('"or"', 'text')) == 0
             assert searcher.count(QSQ('"not"', 'text')) == 117
 

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -146,10 +146,10 @@ class SqliteStorage(Storage):
         If ``keys`` is None, iterates all items.
 
         """
-        if keys is not None: # If keys is none, return all keys, if keys is an empty set, return nothing
+        if keys is not None:  # If keys is none, return all keys, if keys is an empty set, return nothing
             keys = list(keys)
             for k in self._chunks(keys):
-                cursor = self._execute("SELECT * FROM {} WHERE key IN ({})".format(c_id, ','.join(['?']*len(k))), k)
+                cursor = self._execute("SELECT * FROM {} WHERE key IN ({})".format(c_id, ','.join(['?'] * len(k))), k)
                 while True:
                     item = cursor.fetchone()
                     if item is None:

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -146,7 +146,7 @@ class SqliteStorage(Storage):
         If ``keys`` is None, iterates all items.
 
         """
-        if keys is not None: # Need to distinguish between empty sets of keys and no keys specified
+        if keys is not None: # If keys is none, return all keys, if keys is an empty set, return nothing
             keys = list(keys)
             for k in self._chunks(keys):
                 cursor = self._execute("SELECT * FROM {} WHERE key IN ({})".format(c_id, ','.join(['?']*len(k))), k)

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -146,7 +146,7 @@ class SqliteStorage(Storage):
         If ``keys`` is None, iterates all items.
 
         """
-        if keys:
+        if keys is not None: # Need to distinguish between empty sets of keys and no keys specified
             keys = list(keys)
             for k in self._chunks(keys):
                 cursor = self._execute("SELECT * FROM {} WHERE key IN ({})".format(c_id, ','.join(['?']*len(k))), k)

--- a/caterpillar/storage/test/test_sqlite.py
+++ b/caterpillar/storage/test/test_sqlite.py
@@ -91,6 +91,8 @@ def test_sqlite_storage_container(tmp_dir):
     storage.commit()
     assert sum(1 for _ in storage.get_container_items("test")) == 2
     assert sum(1 for _ in storage.get_container_items("test", keys=('2', '3', '4', '5'))) == 4
+    # Test that an empty set of keys returns no rows
+    assert sum(1 for _ in storage.get_container_items("test", keys=[])) == 0
 
     storage.begin()
     storage.delete_container("test")


### PR DESCRIPTION
Addresses #18 and #64 together.

- Frames are stored in a table per text field, whereas a single metadata table is used across all frames
- All get_* methods from IndexReader for frame data now require specifying the field
- QueryStringQuery now requires specifying the text field to search, but MatchAll/MatchSome will combine queries across multiple fields 
- Search scoring is done on a per field basis