### PR TITLE
Refactor plugin interface (#57)

### DIFF
--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1164,7 +1164,7 @@ class IndexWriter(object):
 
         """
         # low level calls to plugin storage subsystem.
-        plugin_id = self.__storage.set_plugin_state(plugin.get_name(),
+        plugin_id = self.__storage.set_plugin_state(plugin.get_type(),
                                                     plugin.get_settings(),
                                                     plugin.get_state())
         return plugin_id
@@ -1174,14 +1174,14 @@ class IndexWriter(object):
         Delete the state corresponding to the given plugin instance.
 
         """
-        self.__storage.delete_plugin_state(plugin.get_name(), plugin_settings=plugin.get_settings())
+        self.__storage.delete_plugin_state(plugin.get_type(), plugin_settings=plugin.get_settings())
 
-    def delete_plugin(self, plugin_name):
+    def delete_plugin_type(self, plugin_type):
         """
-        Delete all plugin data corresponding to the given plugin name.
+        Delete all plugins and corresponding data of the specified ``plugin_type``.
 
         """
-        self.__storage.delete_plugin_state(plugin_name)
+        self.__storage.delete_plugin_state(plugin_type)
 
     def add_fields(self, **fields):
         """
@@ -1516,15 +1516,15 @@ class IndexReader(object):
         Returns the state of the given plugin stored in the index.
 
         """
-        return dict(self.__storage.get_plugin_state(plugin.get_name(), plugin.get_settings()))
+        return dict(self.__storage.get_plugin_state(plugin.get_type(), plugin.get_settings()))
 
     def get_plugin_by_id(self, plugin_id):
         """
-        Returns the plugin_name, settings and state corresponding to the given plugin_id.
+        Returns the plugin_type, settings and state corresponding to the given plugin_id.
 
         """
-        plugin_name, settings, state = self.__storage.get_plugin_by_id(plugin_id)
-        return plugin_name, settings, dict(state)
+        plugin_type, settings, state = self.__storage.get_plugin_by_id(plugin_id)
+        return plugin_type, settings, dict(state)
 
     def list_plugins(self):
         """

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1160,7 +1160,7 @@ class IndexWriter(object):
     def set_plugin_state(self, plugin):
         """ Write the state of the given plugin to the index.
 
-        Any existing state for this plugin will be overwritten.
+        Any existing state for this plugin instance will be overwritten.
 
         """
         # low level calls to plugin storage subsystem.
@@ -1172,7 +1172,7 @@ class IndexWriter(object):
         """
         Delete the state corresponding to the given plugin or plugin name from store.
 
-        Either a plugin instance or a name of a plugin must be specified. The plugin will
+        Either a plugin instance or a name of a plugin must be specified. The plugin instance will
         take priority of both are specified.
 
         """
@@ -1517,7 +1517,9 @@ class IndexReader(object):
         return dict(self.__storage.get_plugin_state(plugin.get_name(), plugin.get_settings()))
 
     def list_plugins(self):
-        """List all plugins and settings that have been stored in this index. """
+        """
+        List all plugin instances that have been stored in this index.
+        """
         return self.__storage.list_known_plugins()
 
 

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1517,6 +1517,14 @@ class IndexReader(object):
         """
         return dict(self.__storage.get_plugin_state(plugin.get_name(), plugin.get_settings()))
 
+    def get_plugin_by_id(self, plugin_id):
+        """
+        Returns the settings and state corresponding to the given plugin_id.
+
+        """
+        settings, state = self.__storage.get_plugin_by_id(plugin_id)
+        return settings, dict(state)
+
     def list_plugins(self):
         """
         List all plugin instances that have been stored in this index.

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1520,11 +1520,11 @@ class IndexReader(object):
 
     def get_plugin_by_id(self, plugin_id):
         """
-        Returns the settings and state corresponding to the given plugin_id.
+        Returns the plugin_name, settings and state corresponding to the given plugin_id.
 
         """
-        settings, state = self.__storage.get_plugin_by_id(plugin_id)
-        return settings, dict(state)
+        plugin_name, settings, state = self.__storage.get_plugin_by_id(plugin_id)
+        return plugin_name, settings, dict(state)
 
     def list_plugins(self):
         """

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1164,9 +1164,10 @@ class IndexWriter(object):
 
         """
         # low level calls to plugin storage subsystem.
-        self.__storage.set_plugin_state(plugin.get_name(),
-                                        plugin.get_settings(),
-                                        plugin.get_state())
+        plugin_id = self.__storage.set_plugin_state(plugin.get_name(),
+                                                    plugin.get_settings(),
+                                                    plugin.get_state())
+        return plugin_id
 
     def delete_plugin_instance(self, plugin):
         """

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -1168,18 +1168,19 @@ class IndexWriter(object):
                                         plugin.get_settings(),
                                         plugin.get_state())
 
-    def delete_plugin_state(self, plugin=None, plugin_name=None):
+    def delete_plugin_instance(self, plugin):
         """
-        Delete the state corresponding to the given plugin or plugin name from store.
-
-        Either a plugin instance or a name of a plugin must be specified. The plugin instance will
-        take priority of both are specified.
+        Delete the state corresponding to the given plugin instance.
 
         """
-        if plugin is not None:
-            self.__storage.delete_plugin_state(plugin.get_name(), plugin_settings=plugin.get_settings())
-        elif plugin_name is not None:
-            self.__storage.delete_plugin_state(plugin_name)
+        self.__storage.delete_plugin_state(plugin.get_name(), plugin_settings=plugin.get_settings())
+
+    def delete_plugin(self, plugin_name):
+        """
+        Delete all plugin data corresponding to the given plugin name.
+
+        """
+        self.__storage.delete_plugin_state(plugin_name)
 
     def add_fields(self, **fields):
         """

--- a/caterpillar/processing/plugin.py
+++ b/caterpillar/processing/plugin.py
@@ -29,12 +29,13 @@ class AnalyticsPlugin(object):
 
     Implementation:
 
-        Plugins need to provide four things:
+        Plugins need to provide five things:
 
         1. An __init__ method that takes at least an ``IndexReader`` as an argument.
-        2. A serialised representation of the plugin's name and settings, to uniquely identify an instance of a plugin.
-        3. A run method to act as a consistent entrypoint. The plugin should be ready after calling this method.
-        4. A serialised representation of the plugin's state, and the means to restore from that representation.
+        2. A string identifying the plugin_type. This is effectively a name for a family of plugin instances.
+        3. A serialised representation of the plugin's settings, to uniquely identify an instance of a plugin.
+        4. A run method to act as a consistent entrypoint. The plugin should be ready after calling this method.
+        5. A serialised representation of the plugin's state, and the means to restore from that representation.
 
         These are provided by providing implementations for the abstract methds of this ``AnalyticsPlugin`` class.
 
@@ -93,9 +94,9 @@ class AnalyticsPlugin(object):
         return
 
     @abc.abstractmethod
-    def get_name(self):
+    def get_type(self):
         """
-        Get the name of this plugin. Used when storing the output of a plugin on an ``Index``.
+        Get the string identifying the type of this plugin. Used when storing the output of a plugin on an ``Index``.
 
         """
         return

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -2,45 +2,94 @@
 # Author: Ryan Stuart <ryan@kapiche.com>, Kris Rogers <kris@kapiche.com>
 """Tests for plugin module."""
 import os
+import ujson as json
+import pytest
 
 from caterpillar import abstract_method_tester
 from caterpillar.processing.index import IndexConfig, IndexWriter, IndexReader
 from caterpillar.processing.plugin import AnalyticsPlugin
 from caterpillar.processing import schema
 from caterpillar.storage.sqlite import SqliteStorage
+from caterpillar.storage import PluginNotFoundError
 from caterpillar.test_util import TestAnalyser
 
 
-class TrivialTestPlugin(AnalyticsPlugin):
+class TestPlugin(AnalyticsPlugin):
     """
     A very simple plugin for testing.
 
     """
+    def __init__(self, indexreader, arbitrary_integer):
+        self.index_reader = indexreader
+        self.arbitrary_integer = arbitrary_integer
+
     @staticmethod
     def get_name():
         return 'trivial_test_plugin'
 
     def run(self):
-        return {
-            'fake_data': {'a': 100}
-        }
+        self.internal_state = [i**2 for i in range(self.arbitrary_integer)]
+
+    def get_state(self):
+        state = dict(internal_state=json.dumps(self.internal_state))
+        return state
+
+    def get_settings(self):
+        return json.dumps(self.arbitrary_integer)
+
+    def restore_from_state(self, state):
+        self.internal_state = json.loads(state['internal_state'])
+        return
 
 
 def test_plugin(index_dir):
     with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'rbU') as f:
         data = f.read()
         analyser = TestAnalyser()
+
         with IndexWriter(index_dir, IndexConfig(SqliteStorage, schema.Schema(text=schema.TEXT(analyser=analyser)))) as \
                 writer:
             writer.add_document(text=data, frame_size=2)
-            writer.run_plugin(TrivialTestPlugin)
+
+        # Run some plugins, and save in the index.
         with IndexReader(index_dir) as reader:
-            assert int(dict(reader.get_plugin_data(TrivialTestPlugin, 'fake_data'))['a']) == 100
+            test_plugins = [TestPlugin(reader, i) for i in range(1, 10)]
+            for plugin in test_plugins:
+                plugin.run()
+
+            with IndexWriter(index_dir) as writer:
+                for i, plugin in enumerate(test_plugins):
+                    writer.set_plugin_state(plugin)
+
+            assert len(reader.list_plugins()) == 9
+
+        # Restore the plugin from the index
+        with IndexReader(index_dir) as reader:
+            restore_plugin = TestPlugin(reader, 1)
+            restore_plugin.load()
+            assert test_plugins[0].internal_state == restore_plugin.internal_state
+
+        # Raise an error if plugin's name-settings combination not found
+        with pytest.raises(PluginNotFoundError):
+            with IndexReader(index_dir) as reader:
+                plugin_not_stored = TestPlugin(reader, 10)
+                plugin_not_stored.load()
+
+        # Delete plugin data from the index
         with IndexWriter(index_dir) as writer:
-            writer.run_plugin(TrivialTestPlugin)  # Overwrite plugin results
+            writer.delete_plugin_state(plugin=restore_plugin)
+
+        with IndexReader(index_dir) as reader:
+            assert len(reader.list_plugins()) == 8
+
+        with IndexWriter(index_dir) as writer:
+            writer.delete_plugin_state(plugin_name='trivial_test_plugin')
+
+        with IndexReader(index_dir) as reader:
+            assert len(reader.list_plugins()) == 0
 
 
 def test_plugin_abc():
-    """This is crap but necessary to get 100% coverage :("""
+    """This is pointless but necessary to get 100% coverage :("""
     abstract_method_tester(AnalyticsPlugin)
-    assert 'Your mum' != 'Awesome'  # While we are writing pointless code we may as well really make it pointless
+    assert True

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -75,7 +75,13 @@ def test_plugin(index_dir):
                 writer.set_plugin_state(plugin)
 
         with IndexReader(index_dir) as reader:
-            assert len(reader.list_plugins()) == 9
+            plugin_list = reader.list_plugins()
+            assert len(plugin_list) == 9
+            # Load each of the plugins by ID
+            for details in plugin_list:
+                state, settings = reader.get_plugin_by_id(details[2])
+            with pytest.raises(PluginNotFoundError):
+                reader.get_plugin_by_id(20)
 
         # Raise an error if plugin's name-settings combination not found
         with pytest.raises(PluginNotFoundError):

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -69,6 +69,14 @@ def test_plugin(index_dir):
             restore_plugin.load()
             assert test_plugins[0].internal_state == restore_plugin.internal_state
 
+        # Make sure we can overwrite a plugin:
+        with IndexWriter(index_dir) as writer:
+            for i, plugin in enumerate(test_plugins):
+                writer.set_plugin_state(plugin)
+
+        with IndexReader(index_dir) as reader:
+            assert len(reader.list_plugins()) == 9
+
         # Raise an error if plugin's name-settings combination not found
         with pytest.raises(PluginNotFoundError):
             with IndexReader(index_dir) as reader:
@@ -87,6 +95,8 @@ def test_plugin(index_dir):
 
         with IndexReader(index_dir) as reader:
             assert len(reader.list_plugins()) == 0
+            # Ensure there is no dangling plugin data
+            assert reader._IndexReader__storage._execute('select count(*) from plugin_data;').fetchone()[0] == 0
 
 
 def test_plugin_abc():

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -79,7 +79,7 @@ def test_plugin(index_dir):
             assert len(plugin_list) == 9
             # Load each of the plugins by ID
             for details in plugin_list:
-                state, settings = reader.get_plugin_by_id(details[2])
+                name, state, settings = reader.get_plugin_by_id(details[2])
             with pytest.raises(PluginNotFoundError):
                 reader.get_plugin_by_id(20)
 

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -77,13 +77,13 @@ def test_plugin(index_dir):
 
         # Delete plugin data from the index
         with IndexWriter(index_dir) as writer:
-            writer.delete_plugin_state(plugin=restore_plugin)
+            writer.delete_plugin_instance(restore_plugin)
 
         with IndexReader(index_dir) as reader:
             assert len(reader.list_plugins()) == 8
 
         with IndexWriter(index_dir) as writer:
-            writer.delete_plugin_state(plugin_name='trivial_test_plugin')
+            writer.delete_plugin(plugin_name='trivial_test_plugin')
 
         with IndexReader(index_dir) as reader:
             assert len(reader.list_plugins()) == 0

--- a/caterpillar/processing/test/test_plugin.py
+++ b/caterpillar/processing/test/test_plugin.py
@@ -24,7 +24,7 @@ class TestPlugin(AnalyticsPlugin):
         self.arbitrary_integer = arbitrary_integer
 
     @staticmethod
-    def get_name():
+    def get_type():
         return 'trivial_test_plugin'
 
     def run(self):
@@ -79,11 +79,11 @@ def test_plugin(index_dir):
             assert len(plugin_list) == 9
             # Load each of the plugins by ID
             for details in plugin_list:
-                name, state, settings = reader.get_plugin_by_id(details[2])
+                plugin_type, state, settings = reader.get_plugin_by_id(details[2])
             with pytest.raises(PluginNotFoundError):
                 reader.get_plugin_by_id(20)
 
-        # Raise an error if plugin's name-settings combination not found
+        # Raise an error if plugin's type-settings combination not found
         with pytest.raises(PluginNotFoundError):
             with IndexReader(index_dir) as reader:
                 plugin_not_stored = TestPlugin(reader, 10)
@@ -97,7 +97,7 @@ def test_plugin(index_dir):
             assert len(reader.list_plugins()) == 8
 
         with IndexWriter(index_dir) as writer:
-            writer.delete_plugin(plugin_name='trivial_test_plugin')
+            writer.delete_plugin_type(plugin_type='trivial_test_plugin')
 
         with IndexReader(index_dir) as reader:
             assert len(reader.list_plugins()) == 0

--- a/caterpillar/storage/__init__.py
+++ b/caterpillar/storage/__init__.py
@@ -181,6 +181,11 @@ class Storage(object):
         return
 
     @abc.abstractmethod
+    def get_plugin_by_id(self, plugin_id):
+        """Return the settings and state of the plugin identified by ID."""
+        return
+
+    @abc.abstractmethod
     def delete_plugin_state(self, plugin_name, plugin_settings=None):
         """Delete all plugin data for ``plugin_name``, or optionally only the data for the ``plugin_settings`` instance.
 
@@ -189,5 +194,5 @@ class Storage(object):
 
     @abc.abstractmethod
     def list_known_plugins(self):
-        """Return a list of (plugin_name, plugin_settings) stored in this index."""
+        """Return a list of (plugin_name, plugin_settings, plugin_id) stored in this index."""
         return

--- a/caterpillar/storage/__init__.py
+++ b/caterpillar/storage/__init__.py
@@ -31,6 +31,10 @@ class StorageNotFoundError(StorageError):
     """No storage object found at the specified location."""
 
 
+class PluginNotFoundError(StorageError):
+    """No data for found for this plugin."""
+
+
 class Storage(object):
     """
     Abstract class used to store key/value data on disk.
@@ -164,4 +168,26 @@ class Storage(object):
     @abc.abstractmethod
     def clear(self):
         """Clears this storage object of all data."""
+        return
+
+    @abc.abstractmethod
+    def set_plugin_state(self, plugin_name, plugin_settings, plugin_state):
+        """Save the state of the given plugin"""
+        return
+
+    @abc.abstractmethod
+    def get_plugin_state(self, plugin_name, plugin_settings):
+        """Return a dictionary of key-value pairs identifying that state of this plugin."""
+        return
+
+    @abc.abstractmethod
+    def delete_plugin_state(self, plugin_name, plugin_settings=None):
+        """Delete all plugin data for ``plugin_name``, or optionally only the data for the ``plugin_settings`` instance.
+
+         """
+        return
+
+    @abc.abstractmethod
+    def list_known_plugins(self):
+        """Return a list of (plugin_name, plugin_settings) stored in this index."""
         return

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -216,11 +216,12 @@ class SqliteStorage(Storage):
 
     def get_plugin_by_id(self, plugin_id):
         """Return the settings and state of the plugin identified by ID."""
-        settings = self._execute('select settings from plugin_registry where plugin_id = ?', [plugin_id]).fetchone()
-        if settings is None:
+        row = self._execute('select name, settings from plugin_registry where plugin_id = ?', [plugin_id]).fetchone()
+        if row is None:
             raise PluginNotFoundError
+        name, settings = row
         state = self._execute("select key, value from plugin_data where plugin_id = ?", [plugin_id]).fetchall()
-        return settings[0], state
+        return name, settings, state
 
     def set_plugin_state(self, plugin_name, plugin_settings, plugin_state):
         """ Set the plugin state in the index to the given state.

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -244,6 +244,7 @@ class SqliteStorage(Storage):
         ).fetchone()[0]
         insert_rows = ((plugin_id, key, value) for key, value in plugin_state.iteritems())
         self._executemany("insert into plugin_data values (?, ?, ?);", insert_rows)
+        return plugin_id
 
     def delete_plugin_state(self, plugin_name, plugin_settings=None):
         """"""

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -216,11 +216,11 @@ class SqliteStorage(Storage):
 
     def get_plugin_by_id(self, plugin_id):
         """Return the settings and state of the plugin identified by ID."""
-        settings = self._execute('select settings from plugin_registry where plugin_id = ?', [plugin_id]).fetchone()[0]
+        settings = self._execute('select settings from plugin_registry where plugin_id = ?', [plugin_id]).fetchone()
         if settings is None:
             raise PluginNotFoundError
         state = self._execute("select key, value from plugin_data where plugin_id = ?", [plugin_id]).fetchall()
-        return settings, state
+        return settings[0], state
 
     def set_plugin_state(self, plugin_name, plugin_settings, plugin_state):
         """ Set the plugin state in the index to the given state.

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -18,7 +18,7 @@ from caterpillar.storage import Storage, StorageNotFoundError, DuplicateContaine
 logger = logging.getLogger(__name__)
 
 
-plugin_table = """
+_plugin_table = """
 begin;
 create table plugin_registry (
     name text,
@@ -77,7 +77,7 @@ class SqliteStorage(Storage):
                            .format(SqliteStorage.CONTAINERS_TABLE))
 
             # Setup plugin data tables
-            cursor.execute(plugin_table)
+            cursor.execute(_plugin_table)
 
         elif readonly:
             self._db_connection = apsw.Connection(db, flags=apsw.SQLITE_OPEN_READONLY)
@@ -228,11 +228,16 @@ class SqliteStorage(Storage):
         """"""
         if plugin_settings is not None:
             self._execute(
-                "pragma foreign_keys=ON; delete from plugin_registry where name = ? and settings = ?",
+                "pragma foreign_keys=ON;"
+                "delete from plugin_registry where name = ? and settings = ?;"
+                "pragma foreign_keys=OFF;",
                 [plugin_name, plugin_settings]
             )
         else:
-            self._execute("pragma foreign_keys=ON; delete from plugin_registry where name = ?", [plugin_name])
+            self._execute("pragma foreign_keys=ON; "
+                          "delete from plugin_registry where name = ?;"
+                          "pragma foreign_keys=OFF;",
+                          [plugin_name])
 
     def list_known_plugins(self):
         """ Return a list of (name, settings) pairs for each plugin stored in the index. """


### PR DESCRIPTION
Extend the notion of a plugin to an instance of an object, with tools for explicitly managing, generating, saving and restoring state on an index.

This new interface makes explicit the lifecycle of a plugin, and plugin data is now centralised in a single set of tables, rather than spread through arbitrary containers.

This should be enough to address #57 
