### PR TITLE
Minimally invasive indexing

### DIFF
--- a/caterpillar/processing/analysis/analyse.py
+++ b/caterpillar/processing/analysis/analyse.py
@@ -4,7 +4,7 @@
 from caterpillar.processing.analysis import stopwords
 from caterpillar.processing.analysis.filter import StopFilter, PositionalLowercaseWordFilter, BiGramFilter, \
     PotentialBiGramFilter, OuterPunctuationFilter, PossessiveContractionFilter
-from caterpillar.processing.analysis.tokenize import WordTokenizer, EverythingTokenizer, \
+from caterpillar.processing.analysis.tokenize import EverythingTokenizer, \
     SimpleWordTokenizer, DateTimeTokenizer
 
 
@@ -49,7 +49,7 @@ class DefaultAnalyser(Analyser):
     """
     _tokenizer = SimpleWordTokenizer(detect_compound_names=True)
 
-    def __init__(self, stopword_list=None):
+    def __init__(self, stopword_list=[], min_word_size=1):
         super(DefaultAnalyser, self).__init__()
         if stopword_list is None:
             stopword_list = stopwords.ENGLISH
@@ -57,7 +57,7 @@ class DefaultAnalyser(Analyser):
         self._filters = [
             OuterPunctuationFilter(leading_allow=['@', '#']),
             PossessiveContractionFilter(),
-            StopFilter(stopword_list, minsize=stopwords.MIN_WORD_SIZE),
+            StopFilter(stopword_list, minsize=min_word_size),
             PositionalLowercaseWordFilter(0),
         ]
 

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -926,13 +926,16 @@ class IndexReader(object):
         plugin_type, settings, state = self.__storage.get_plugin_by_id(plugin_id)
         return plugin_type, settings, dict(state)
 
-    def get_case_fold_terms(self, text_field, merge_threshold=0.7):
+    def get_case_fold_terms(self, include_fields=None, merge_threshold=0.7):
         """Suggest case normalised variations on terms.
 
         Operates across all fields in the corpus.
 
         """
-        frequencies_index = {term: freq for term, freq in self.get_frequencies(text_field)}
+        # Merge frequencies across all fields specified
+        frequencies_index = {
+            term: freq for term, freq in self.__storage.iterate_term_frequencies(include_fields=include_fields)
+        }
 
         normalise_variants = []
 

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -926,7 +926,7 @@ class IndexReader(object):
         plugin_type, settings, state = self.__storage.get_plugin_by_id(plugin_id)
         return plugin_type, settings, dict(state)
 
-    def get_case_fold_terms(self, include_fields=None, merge_threshold=0.7):
+    def get_case_fold_terms(self, include_fields=None, exclude_fields=None, merge_threshold=0.7):
         """Suggest case normalised variations on terms.
 
         Operates across all fields in the corpus.
@@ -934,7 +934,9 @@ class IndexReader(object):
         """
         # Merge frequencies across all fields specified
         frequencies_index = {
-            term: freq for term, freq in self.__storage.iterate_term_frequencies(include_fields=include_fields)
+            term: freq for term, freq in self.__storage.iterate_term_frequencies(
+                include_fields=include_fields, exclude_fields=exclude_fields
+            )
         }
 
         normalise_variants = []

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -933,6 +933,9 @@ class IndexReader(object):
 
         """
         # Merge frequencies across all fields specified
+        # Note that this requires loading all of the vocabulary into main memory and should be used
+        # with care on extremely large vocabularies. Across 1.4 million terms in Simple Wikipedia
+        # this takes about 4 seconds and consumes ~150MB of memory.
         frequencies_index = {
             term: freq for term, freq in self.__storage.iterate_term_frequencies(
                 include_fields=include_fields, exclude_fields=exclude_fields
@@ -961,7 +964,7 @@ class IndexReader(object):
         """
         return self.__storage.list_known_plugins()
 
-    def detect_significant_ngrams(self, min_count=5, threshold=40, n=2, include_fields=None, exclude_fields=None):
+    def detect_significant_ngrams(self, min_count=5, threshold=40, include_fields=None, exclude_fields=None):
         """
         Find significant n-grams within the index.
 
@@ -971,8 +974,6 @@ class IndexReader(object):
 
             threshold: the minimum score to be considered a significant n-gram
 
-            n: the size of the n-grams to find. Currently only n=2 is supported
-
             include_fields, exclude_fields
 
         Returns
@@ -981,6 +982,8 @@ class IndexReader(object):
                 [('hot', 'apple', 'pie'), ('cream', 'cheese'), ('sweet', 'potato')]
 
         Notes
+
+            Currently only n=2 (bigram detection) is supported.
 
             Uses the same algorithm as the find_bi_gram_words function, but counts frequency by the
             number of frames a match occurs in, rather than the raw frequency.

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -428,6 +428,7 @@ class IndexWriter(object):
                 else:
                     sentences_by_frames = [[paragraph.value]]
                 for sentence_list in sentences_by_frames:
+                    token_position = 0
                     # Build our frames
                     frame = {
                         '_field': field_name,
@@ -447,9 +448,11 @@ class IndexWriter(object):
                             if not token.stopped:
                                 # Record word positions
                                 try:
-                                    frame['_positions'][token.value].append(token.index)
+                                    frame['_positions'][token.value].append(token_position)
                                 except KeyError:
-                                    frame['_positions'][token.value] = [token.index]
+                                    frame['_positions'][token.value] = [token_position]
+
+                            token_position += 1
 
                     # Build the final frame and add to the index
                     frame.update(shell_frame)
@@ -500,74 +503,9 @@ class IndexWriter(object):
         ``last_deleted_documents`` contains the ID's of documents that were present in the
         index and deleted during the last transaction.
 
+
         """
         self.__storage.delete_documents([document_id])
-
-    def fold_term_case(self, text_field, merge_threshold=0.7):
-        """
-        Perform case folding on this index, merging words into names (camel cased word or phrase) and vice-versa
-        depending ``merge_threshold``.
-
-        ``merge_threshold`` (float) is used to test when to merge two variants. When the ratio between word and name
-        version of a term falls below this threshold the merge is carried out.
-
-        The statistics used to determine which terms to fold are calculated from ``text_field`` and only instances
-        of terms in that field will be modified.
-
-        This method only works on content committed to disk. It will need to be run in a separate writer if you
-        wish to fold newly added documents.
-
-        """
-
-        merges = []
-
-        reader = IndexReader(self._path)
-        frequencies_index = dict(reader.get_frequencies(text_field))
-        for w, freq in frequencies_index.iteritems():
-            if w.islower() and w.title() in frequencies_index:
-                freq_name = frequencies_index[w.title()]
-                if freq / freq_name < merge_threshold:
-                    # Merge into name
-                    logger.debug(u'Merging {} into {}'.format(w, w.title()))
-                    merges.append((w, w.title()))
-
-                elif freq_name / freq < merge_threshold:
-                    # Merge into word
-                    logger.debug(u'Merging {} into {}'.format(w.title(), w))
-                    merges.append((w.title(), w))
-
-        count = len(merges)
-        self.merge_terms(merges, text_field)
-
-        logger.debug("Merged {} terms during case folding.".format(count))
-
-    def merge_terms(self, merges, text_field, bigram_max_char_gap=2):
-        """
-        Merge the terms in ``merges`` across the whole index.
-
-        ``merges`` (list) should be a list of str tuples of the format ``(old_term, new_term,)``. If new_term is ``''``
-        then old_term is removed. N-grams can be specified by supplying a str tuple instead of str for the old term.
-        For example::
-
-            >>> (('hot', 'dog'), 'hot dog')
-
-        """
-        count = len(merges)
-
-        # Run through merges, and dispatch to unigram/bigram merging as appropriate
-        for terms, new_term in merges:
-            if isinstance(terms, basestring):
-                if new_term:
-                    self.__storage._merge_term_variation(terms, new_term, text_field)
-                else:  # Map falsey values to the empty string, removing them from consideration
-                    self.__storage._merge_term_variation(terms, '', text_field)
-            else:
-                left_term, right_term = terms
-                self.__storage._merge_bigrams(
-                    terms[0], terms[1], new_term, text_field, max_char_gap=bigram_max_char_gap
-                )
-
-        logger.debug("Merged {} terms during manual merge.".format(count))
 
     def set_plugin_state(self, plugin):
         """ Write the state of the given plugin to the index.
@@ -774,16 +712,14 @@ class IndexReader(object):
 
     def get_term_association(self, term, association, field):
         """Returns a count of term associations between ``term`` (str) and ``association`` (str)."""
-
-        term, associations = next(
-            self.__storage.iterate_associations(term=term, association=association, include_fields=[field])
-        )
-        if term is None:
+        try:
+            term, associations = next(
+                self.__storage.iterate_associations(term=term, association=association, include_fields=[field])
+            )
+        except StopIteration:
             raise KeyError('"{}" not associated with term "{}" or has no associations.'.format(association, term))
 
-        count = associations[association]
-
-        return count
+        return associations[association]
 
     def get_frequencies(self, field):
         """
@@ -990,11 +926,121 @@ class IndexReader(object):
         plugin_type, settings, state = self.__storage.get_plugin_by_id(plugin_id)
         return plugin_type, settings, dict(state)
 
+    def get_case_fold_terms(self, text_field, merge_threshold=0.7):
+        """Suggest case normalised variations on terms.
+
+        Operates across all fields in the corpus.
+
+        """
+        frequencies_index = {term: freq for term, freq in self.get_frequencies(text_field)}
+
+        normalise_variants = []
+
+        for w, freq in frequencies_index.items():
+            if w.islower() and w.title() in frequencies_index:
+                freq_name = frequencies_index[w.title()]
+
+                if freq / freq_name < merge_threshold:
+                    # Merge into name
+                    normalise_variants.append((w, w.title()))
+
+                elif freq_name / freq < merge_threshold:
+                    # Merge into word
+                    normalise_variants.append((w.title(), w))
+
+        return normalise_variants
+
     def list_plugins(self):
         """
         List all plugin instances that have been stored in this index.
         """
         return self.__storage.list_known_plugins()
+
+    def detect_significant_ngrams(self, min_count=5, threshold=40, n=2, include_fields=None, exclude_fields=None):
+        """
+        Find significant n-grams within the index.
+
+        Args
+
+            min_count: the minimum number of frames a bigram must occur in to be considered
+
+            threshold: the minimum score to be considered a significant n-gram
+
+            n: the size of the n-grams to find. Currently only n=2 is supported
+
+            include_fields, exclude_fields
+
+        Returns
+
+            bigrams: a list of tuples of tokens on the index in their positional order. For example:
+                [('hot', 'apple', 'pie'), ('cream', 'cheese'), ('sweet', 'potato')]
+
+        Notes
+
+            Uses the same algorithm as the find_bi_gram_words function, but counts frequency by the
+            number of frames a match occurs in, rather than the raw frequency.
+
+            Unlike the find_bi_gram_words function, this method operates on the positions index
+            directly. This  is significantly faster, but sensitive to how documents are analysed.
+            For example the DefaultAnalyser ignores most punctuation so 'hello, friend' and 'hello
+            friend' would both be considered bigrams by this detection method. If punctuation is
+            important than the analyser needs to tokenize punctuation as individual tokens.
+
+        """
+        return list(self.__storage.find_significant_bigrams(
+            include_fields=include_fields, exclude_fields=exclude_fields, min_count=5, threshold=40
+        ))
+
+    def search_ngrams(self, ngrams, include_fields=None, exclude_fields=None):
+        """
+        Search for frames containing the specified list of n-grams on the given index.
+
+        Currently only searching for bigrams (n = 2) is supported.
+
+        Args
+
+            ngrams: iterator of n-gram tuples, in positional order
+                Currently only 2-tuples (bigrams) are supported.
+
+            include_fields, exclude_fields
+
+        Returns
+
+            generator of (ngram_tuple, frame_id, frequency) tuples
+
+        """
+        return self.__storage.iterate_bigram_positions(
+            ngrams, include_fields=include_fields, exclude_fields=exclude_fields
+        )
+
+    def get_term_frequency_vectors(self, frame_ids=None, include_fields=None, exclude_fields=None, weighting='tf'):
+        """
+        Iterate through term-frequency vectors for frames in this index.
+
+        Args
+
+            include_fields: list of unstructured fields to include in the analysis.
+                By default this is None, and all fields are included if exclude_fields is also None.
+
+            exclude_fields: list of unstructured fields to exclude from the analysis.
+                If include_fields is not None, this argument is ignored.
+
+            frame_ids: an iterator of frame_ids to consider.
+                If this is provided then both include_fields and exclude_fields are ignored.
+
+            weighting: the weighting for each term.
+                Currently only term-frequency ('tf') is supported.
+
+        Returns
+
+            Generator of (frame_id, {term1: frequency, term2: frequency}) tuples.
+
+        """
+        return self.__storage.iterate_term_frequency_vectors(
+            weighting=weighting,
+            include_fields=include_fields, exclude_fields=exclude_fields,
+            frame_ids=frame_ids
+        )
 
 
 def find_bi_gram_words(frames, min_count=5, threshold=40.0):

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -451,7 +451,7 @@ def test_alice_case_folding(index_dir):
             writer.add_document(text=data)
 
         with IndexReader(index_dir) as reader:
-            normalise_case = reader.get_case_fold_terms('text')
+            normalise_case = reader.get_case_fold_terms(['text'])
             for term, normalise_term in normalise_case:
                 assert term.title() == normalise_term or term.lower() == normalise_term
                 assert reader.get_term_frequency(term, 'text') < reader.get_term_frequency(normalise_term, 'text')

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -9,13 +9,18 @@ import shutil
 import tempfile
 import multiprocessing as mp
 import multiprocessing.dummy as mt  # threading dummy with same interface as multiprocessing
+import os
+from collections import Counter
 
 import pytest
 
 from caterpillar.storage import Storage
 from caterpillar.storage.sqlite import SqliteStorage
 from caterpillar.processing.analysis.analyse import EverythingAnalyser
-from caterpillar.processing.index import *
+from caterpillar.processing.index import (
+    IndexWriter, IndexReader, find_bi_gram_words, IndexConfig, IndexNotFoundError, DocumentNotFoundError,
+    SettingNotFoundError, IndexWriteLockedError, VERSION
+)
 from caterpillar.processing.schema import ID, NUMERIC, TEXT, FieldType, Schema
 from caterpillar.searching.query.querystring import QueryStringQuery
 from caterpillar.test_util import TestAnalyser, TestBiGramAnalyser
@@ -140,6 +145,9 @@ def test_index_alice(index_dir):
             assert sum(1 for _ in reader.get_term_positions('nice', 'text')) == 3
             assert sum(1 for _ in reader.get_term_positions('key', 'text')) == 5
 
+            assoc_index = {term: values for term, values in reader.get_associations_index('text')}
+            assert 'Alice' in assoc_index
+
             assert reader.get_term_association('Alice', 'poor', 'text') == \
                 reader.get_term_association('poor', 'Alice', 'text') == 3
             assert reader.get_term_association('key', 'golden', 'text') == \
@@ -150,6 +158,9 @@ def test_index_alice(index_dir):
 
             with pytest.raises(KeyError):
                 reader.get_term_association('Alice', 'nonsenseterminthisindex', 'text')
+
+            with pytest.raises(KeyError):
+                reader.get_term_positions('nonseneterminthisindex', 'text')
 
             assert reader.get_vocab_size('text') == sum(1 for _ in reader.get_frequencies('text')) == 500
             assert reader.get_term_frequency('Alice', 'text') == 23
@@ -279,6 +290,16 @@ def test_index_alice_bigram_discovery(index_dir):
             bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 4
             assert 'golden key' in bi_grams
+            index_bigrams = reader.detect_significant_ngrams(min_count=5, threshold=40)
+            assert ('golden', 'key') in index_bigrams
+
+            # Increasing the threshold should result in fewer bigrams
+            old_n = 1e6  # Nonsense high value for first comparison.
+            for threshold in range(0, 100, 10):
+                index_bigrams = reader.detect_significant_ngrams(min_count=5, threshold=threshold)
+                n_bigrams = len(index_bigrams)
+                assert n_bigrams <= old_n
+                old_n = n_bigrams
 
 
 def test_moby_bigram_discovery(index_dir):
@@ -290,7 +311,13 @@ def test_moby_bigram_discovery(index_dir):
         with IndexReader(index_dir) as reader:
             bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 10
-            assert 'steering oar' in bi_grams
+            assert 'ivory leg' in bi_grams
+            index_bigrams = reader.detect_significant_ngrams(min_count=5, threshold=40)
+            assert ('ivory', 'leg') in index_bigrams
+
+            for bigram in index_bigrams:
+                found_positions = list(reader.search_ngrams([bigram]))
+                assert len(found_positions) >= 5
 
 
 def test_wikileaks_bigram_discovery(index_dir):
@@ -302,6 +329,13 @@ def test_wikileaks_bigram_discovery(index_dir):
         with IndexReader(index_dir) as reader:
             bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 29
+            index_bigrams = reader.detect_significant_ngrams(min_count=5, threshold=40, include_fields=['text'])
+            assert len(index_bigrams) == 30
+            assert ('internet', 'service') in index_bigrams
+
+            for bigram in index_bigrams:
+                found_positions = list(reader.search_ngrams([bigram], include_fields=['text']))
+                assert len(found_positions) >= 5
 
 
 def test_employee_survet_bigram_discovery(index_dir):
@@ -313,247 +347,114 @@ def test_employee_survet_bigram_discovery(index_dir):
         with IndexReader(index_dir) as reader:
             bi_grams = find_bi_gram_words(reader.get_frames('text'))
             assert len(bi_grams) == 7
+            index_bigrams = reader.detect_significant_ngrams(min_count=5, threshold=40)
+            assert len(index_bigrams) == 16
+            assert ('pay', 'rise') in index_bigrams
+
+
+def test_detect_case_variations(index_dir):
+    """Test statistics of detected case normalisations. """
+    return None
+
+
+def test_term_frequency_vectors(index_dir):
+    """Test iterating through the term_frequency vectors. """
+    with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'r') as f:
+        data = f.read()
+        with IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT))) as writer:
+            writer.add_document(text=data, frame_size=2)
+
+    with IndexReader(index_dir) as reader:
+        # the term-frequency vectors should accumulate to the same state as the vocabulary statistics
+        tf_vectors = reader.get_term_frequency_vectors()
+        # Ensure no duplicate frames come through
+        total_frames = set()
+        frame_count = 0
+        term_counts = Counter()
+
+        for frame, vector in tf_vectors:
+            total_frames.add(frame)
+            for term in vector:
+                term_counts[term] += 1
+            frame_count += 1
+
+        assert frame_count == len(total_frames)
+        # Some frames are degenerate and contain only punctuation
+        assert frame_count != reader.get_frame_count('text')
+
+        for term, frequency in reader.get_frequencies('text'):
+            assert term_counts[term] == frequency
+
+        # Now with a subset of frames, like for example from a search.
+        tf_vectors = reader.get_term_frequency_vectors(frame_ids=range(1, 100))
+        total_frames = set()
+        frame_count = 0
+        term_counts = Counter()
+
+        for frame, vector in tf_vectors:
+            total_frames.add(frame)
+            for term in vector:
+                term_counts[term] += 1
+            frame_count += 1
+
+        for frequency in term_counts.values():
+            assert frequency <= 99
+
+        assert frame_count == len(total_frames)
 
 
 def test_index_alice_merge_bigram(index_dir):
+    """Test constructing indexes with the bigram analyser. """
     with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'r') as f:
         f.seek(0)
         data = f.read()
+
         with IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT))) as writer:
             writer.add_document(text=data)
+
         with IndexReader(index_dir) as reader:
-            bi_grams = find_bi_gram_words(reader.get_frames('text'), min_count=3)
+            min_bigram_count = 3
+            bi_grams = find_bi_gram_words(reader.get_frames('text'), min_count=min_bigram_count)
+            # Remove the detected bigram 'kid gloves', that only ever occurs after 'white kid'
+            # In the bigram analyzer, detected bigrams are consumed in lexical order.
+            bi_grams = [b for b in bi_grams if b != 'kid gloves']
 
         bigram_index = os.path.join(tempfile.mkdtemp(), "bigram")
-        merge_index = os.path.join(tempfile.mkdtemp(), "merge")
         try:
-            analyser = TestBiGramAnalyser(bi_grams, )
+            analyser = TestBiGramAnalyser(bi_grams)
             with IndexWriter(bigram_index, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser)))) as writer:
                 writer.add_document(text=data)
 
-            terms_to_merge = [[b.split(' '), b] for b in bi_grams]
+            # Verify found bigrams exist in both
+            with IndexReader(index_dir) as original_reader, IndexReader(bigram_index) as bigrams:
 
-            # Potential bi-grams 'white kid' & 'kid gloves' form the tri-gram 'white kid gloves'.
-            # The bi-gram analyser will match 'white kid' first due to lexical order, consuming the 'kid' token.
-            # Subsequently, 'kid gloves' will not be matched. This manual test using `terms_to_merge` however, attempts
-            # to convert the bi-grams in alphabetic order, hence 'kid gloves' will be matched first.
-            for i, m in enumerate(terms_to_merge):
-                if m[1] == 'kid gloves':
-                    break
-            # ...so, here we just re-order 'kid gloves' to the end of `merges`
-            # to emulate the behavior of the bi-gram analyser
-            terms_to_merge.append(terms_to_merge.pop(i))
+                for bigram in bi_grams:
+                    assert bigrams.get_term_frequency(bigram, 'text')
 
-            analyser = TestAnalyser()
-            with IndexWriter(merge_index, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser)))) as writer:
-                writer.add_document(text=data)
-                writer.merge_terms(terms_to_merge, 'text')
+                for term, frequency in original_reader.get_frequencies('text'):
+                    try:
+                        assert bigrams.get_term_frequency(term, 'text') <= frequency
+                    except KeyError:  # The bigram analyzer and default analyzer behave differently
+                        continue
 
-            # Verify indexes match
-            with IndexReader(merge_index) as merges, IndexReader(bigram_index) as bigrams:
-                # Frequencies
-                assert bigrams.get_term_frequency('golden key', 'text') == 6
-                assert bigrams.get_term_frequency('golden', 'text') == 1
-                assert bigrams.get_term_frequency('key', 'text') == 3
-                merge_frequencies = {k: v for k, v in merges.get_frequencies('text')}
-                merge_associations = {k: v for k, v in merges.get_associations_index('text')}
-                for term, frequency in bigrams.get_frequencies('text'):
-                    assert merge_frequencies[term] == frequency
-                # Associations
-                merge_associations = {k: v for k, v in merges.get_associations_index('text')}
-                for term, associations in bigrams.get_associations_index('text'):
-                    assert merge_associations[term] == associations
-                # Term positions index
-                frame_mappings = {}
-                merge_frames = sorted({k: v for k, v in merges.get_frames('text')}.values(),
-                                      key=lambda t: t['_sequence_number'])
-                bigram_frames = sorted({k: v for k, v in bigrams.get_frames('text')}.values(),
-                                       key=lambda t: t['_sequence_number'])
-                for i, merge_frame in enumerate(merge_frames):
-                    frame_mappings[bigram_frames[i]['_id']] = merge_frame['_id']
-                # Global positions
-                merge_positions = {k: v for k, v in merges.get_positions_index('text')}
-                for term, positions in bigrams.get_positions_index('text'):
-                    for f_id, f_positions in positions.iteritems():
-                        assert f_positions == merge_positions[term][frame_mappings[f_id]]
-
-                with pytest.raises(Exception):
-                    merges.merge_terms([[('hot', 'dog',), '']], 'text')
-
-            with IndexWriter(merge_index) as writer:
-                writer.merge_terms([[('garbage', 'term',), 'test']], 'text')
-                writer.merge_terms([[('Alice', 'garbage',), 'test']], 'text')
-            with IndexReader(merge_index) as reader:
-                with pytest.raises(KeyError):
-                    reader.get_term_frequency('garbage term', 'text')
-                with pytest.raises(KeyError):
-                    reader.get_term_frequency('Alice garbage', 'text')
         finally:
             shutil.rmtree(bigram_index)
-            shutil.rmtree(merge_index)
 
 
-def test_bigram_merge_char_thresh(index_dir):
+def test_alice_case_folding(index_dir):
+    """Test constructing indexes with the bigram analyser. """
     with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'r') as f:
         f.seek(0)
         data = f.read()
+
         with IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT))) as writer:
             writer.add_document(text=data)
 
-    # Don't merge any bigrams
-    with IndexWriter(index_dir) as writer:
-        writer.merge_terms(
-            [[('golden', 'key'), 'golden key'], [('twinkle', 'twinkle'), 'twinkle twinkle']],
-            'text', bigram_max_char_gap=0
-        )
-
-    with IndexReader(index_dir) as reader:
-        with pytest.raises(KeyError):
-            reader.get_term_frequency('golden key', 'text') == 0
-
-    with IndexWriter(index_dir) as writer:
-        writer.merge_terms([[('golden', 'key',), 'golden key']], 'text', bigram_max_char_gap=2)
-
-    with IndexReader(index_dir) as reader:
-        assert reader.get_term_frequency('golden key', 'text') == 6
-
-
-def test_index_moby_case_folding(index_dir):
-    with open(os.path.abspath('caterpillar/test_resources/moby.txt'), 'r') as f:
-        data = f.read()
-        analyser = TestAnalyser()
-        writer = IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser))))
-        with writer:
-            writer.add_document(text=data, frame_size=2)
-
-        with writer:
-            writer.fold_term_case('text')
-
         with IndexReader(index_dir) as reader:
-            with pytest.raises(KeyError):
-                reader.get_term_positions('flask', 'text')
-            with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('flask', 'text')
-            assert reader.get_term_frequency('Flask', 'text') == 88
-            assert reader.get_term_association('Flask', 'person', 'text') == \
-                reader.get_term_association('person', 'Flask', 'text') == 2
-
-            with pytest.raises(KeyError):
-                reader.get_term_positions('Well', 'text')
-            with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('Well', 'text')
-            assert reader.get_term_frequency('well', 'text') == 194
-            assert reader.get_term_association('well', 'whale', 'text') == \
-                reader.get_term_association('whale', 'well', 'text') == 20
-
-            with pytest.raises(KeyError):
-                reader.get_term_positions('Whale', 'text')
-            with pytest.raises(KeyError):
-                assert not reader.get_term_frequency('Whale', 'text')
-            assert reader.get_term_frequency('whale', 'text') == 695
-            assert reader.get_term_association('whale', 'American', 'text') == \
-                reader.get_term_association('American', 'whale', 'text') == 9
-
-            assert reader.get_term_frequency('T. HERBERT', 'text') == 1
-            assert sum(1 for _ in reader.get_frequencies('text')) == 20542
-
-
-def test_index_merge_terms(index_dir):
-    """Test merging terms together."""
-    with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'r') as f:
-        data = f.read()
-        analyser = TestAnalyser()
-        writer = IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser))))
-        with writer:
-            writer.add_document(text=data, frame_size=2)
-
-        with IndexReader(index_dir) as reader:
-            assert reader.get_term_frequency('alice', 'text') == 86
-            assert reader.get_term_association('alice', 'creatures', 'text') == 1
-            assert sum(1 for _ in reader.get_term_positions('alice', 'text')) == 86
-
-            assert reader.get_term_frequency('party', 'text') == 8
-            assert reader.get_term_association('party', 'creatures', 'text') == 1
-            assert reader.get_term_association('party', 'assembled', 'text') == 1
-            assert sum(1 for _ in reader.get_term_positions('party', 'text')) == 8
-
-        writer = IndexWriter(index_dir)
-        with writer:
-            writer.merge_terms(merges=[
-                ('Alice', '',),  # delete
-                ('alice', 'tplink',),  # rename
-                ('Eaglet', 'party',),  # merge
-                ('idonotexist', '',),  # non-existent term
-            ], text_field='text')
-
-        with IndexReader(index_dir) as reader:
-            with pytest.raises(KeyError):
-                reader.get_term_frequency('Alice', 'text')
-            with pytest.raises(KeyError):
-                reader.get_term_positions('Alice', 'text')
-
-            assert reader.get_term_frequency('tplink', 'text') == 86
-            assert reader.get_term_association('tplink', 'creatures', 'text') == 1
-            assert sum(1 for _ in reader.get_term_positions('tplink', 'text')) == 86
-
-            assert reader.get_term_frequency('party', 'text') == 10
-            assert reader.get_term_association('party', 'creatures', 'text') == 1
-            assert reader.get_term_association('party', 'assembled', 'text') == 1
-            assert sum(1 for _ in reader.get_term_positions('party', 'text')) == 10
-
-
-def test_index_alice_case_folding(index_dir):
-    with open(os.path.abspath('caterpillar/test_resources/alice.txt'), 'r') as f:
-        data = f.read()
-        analyser = TestAnalyser()
-        writer = IndexWriter(index_dir, IndexConfig(SqliteStorage,
-                                                    Schema(text=TEXT(analyser=analyser),
-                                                           document=TEXT(analyser=analyser, indexed=False))))
-        with writer:
-            writer.add_document(text=data, document='alice.txt', frame_size=2)
-
-        with writer:
-            writer.fold_term_case('text')
-
-        with IndexReader(index_dir) as reader:
-
-            # Check that associations never exceed frequency of either term
-            associations = {k: v for k, v in reader.get_associations_index('text')}
-            frequencies = {k: v for k, v in reader.get_frequencies('text')}
-            for term, term_associations in associations.iteritems():
-                for other_term, assoc in term_associations.items():
-                    assert assoc <= frequencies[term] and assoc <= frequencies[other_term]
-
-            # Check frequencies against positions
-            positions_index = {k: v for k, v in reader.get_positions_index('text')}
-            for term, freq in frequencies.items():
-                assert freq == len(positions_index[term])
-
-
-def test_index_case_fold_no_new_term(index_dir):
-    """
-    Test a dataset that has only uppercase occurrences of a term where it mostly appears at the start of the 1 word
-    sentence. This results in those occurrences being converted to lower case (because they are at the start of a
-    sentence) then we attempt to merge with the 1 upper case occurrence. Previously we wrongly assumed in the merge code
-    that all terms would have an existing entry in the associations matrix but this isn't this case with this tricky
-    dataset.
-
-    """
-    with open(os.path.abspath('caterpillar/test_resources/case_fold_no_assoc.csv'), 'rbU') as f:
-        analyser = TestAnalyser()
-        writer = IndexWriter(index_dir, IndexConfig(SqliteStorage, Schema(text=TEXT(analyser=analyser))))
-        with writer:
-            csv_reader = csv.reader(f)
-            for row in csv_reader:
-                writer.add_document(text=row[0])
-
-        with writer:
-            writer.fold_term_case('text')
-
-        with IndexReader(index_dir) as reader:
-            assert reader.get_term_frequency('stirling', 'text') == 6
-            with pytest.raises(KeyError):
-                reader.get_term_frequency('Stirling', 'text')
+            normalise_case = reader.get_case_fold_terms('text')
+            for term, normalise_term in normalise_case:
+                assert term.title() == normalise_term or term.lower() == normalise_term
+                assert reader.get_term_frequency(term, 'text') < reader.get_term_frequency(normalise_term, 'text')
 
 
 def test_index_utf8(index_dir):
@@ -722,7 +623,7 @@ def test_metadata_only_retrieval_deletion(index_dir):
 
 
 def test_field_names(index_dir):
-    """Test we can retrieve metadata only documents"""
+    """Test fields with names containing spaces."""
     schema = {"Don't Like": TEXT, "Would Like": TEXT}
     document1 = {"Don't Like": 'The scenery was unpleasant.', "Would Like": 'More cats.'}
     config = IndexConfig(SqliteStorage, schema=Schema(**schema))

--- a/caterpillar/searching/query/querystring.py
+++ b/caterpillar/searching/query/querystring.py
@@ -215,21 +215,21 @@ class _QueryStringParser(object):
                             matched_frames = self.index.get_term_positions(term, self.text_field)
                             node.frame_ids.update(set(matched_frames.keys()))
                             node.matched_terms.add(term)
-                            for frame_id, positions in matched_frames.iteritems():
+                            for frame_id, frequency in matched_frames.iteritems():
                                 try:
-                                    node.term_frequencies[frame_id][term] = len(positions)
+                                    node.term_frequencies[frame_id][term] = frequency
                                 except KeyError:
-                                    node.term_frequencies[frame_id] = {term: len(positions)}
+                                    node.term_frequencies[frame_id] = {term: frequency}
                 else:
                     try:
                         matched_frames = self.index.get_term_positions(value, self.text_field)
                         node.frame_ids.update(set(matched_frames.keys()))
                         node.matched_terms.add(value)
-                        for frame_id, positions in matched_frames.iteritems():
+                        for frame_id, frequency in matched_frames.iteritems():
                             try:
-                                node.term_frequencies[frame_id][value] = len(positions)
+                                node.term_frequencies[frame_id][value] = frequency
                             except KeyError:
-                                node.term_frequencies[frame_id] = {value: len(positions)}
+                                node.term_frequencies[frame_id] = {value: frequency}
                     except KeyError:
                         # Term not matched in index
                         pass

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -959,7 +959,8 @@ class SqliteReader(StorageReader):
         """
         fields = include_fields or exclude_fields or []
         valid_fields = self.structured_fields if structured else self.unstructured_fields
-        invalid_fields = [field for field in fields if field not in valid_fields]
+        # Catch None as a valid field to allow current reader level interface to specify None as a field.
+        invalid_fields = [field for field in fields if field not in valid_fields and field is not None]
 
         if invalid_fields:
             raise ValueError('Invalid fields: {} do not exist or are not indexed'.format(invalid_fields))

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -18,11 +18,11 @@ performed.
 import logging
 import os
 
-import ujson as json
 import apsw
 
 from caterpillar.storage import StorageWriter, StorageReader, Storage, StorageNotFoundError, \
     DuplicateStorageError, PluginNotFoundError
+
 from ._sqlite_schema import disk_schema, cache_schema, prepare_flush, flush_cache
 
 
@@ -165,247 +165,6 @@ class SqliteWriter(StorageWriter):
         for f in field_names:
             self._execute('insert into structured_field(name) values(?)', [f])
 
-    def _merge_term_variation(self, old_term, new_term, field):
-        """Mangle the terms in the stored vocabulary.
-
-        term_mapping is a list of pairs ('old term', 'new term'). The old_term mapping can
-        itself be a tuple, in which case all individual terms in old_term are mapped to
-        'new_term'.
-
-        If new term is falsey, that term representation will be removed from the vocabulary.
-
-        If old_term is not present in the vocabulary, it will be ignored.
-
-        Note that this operation operates only on content that has been commited to disk already:
-        this function must be called in a write transaction *after* the documents to operate on
-        have been added.
-
-        This is a destructive operation that does not respect the writer interface and should be
-        used with care. In memory contents are first flushed to disk, and commit is executed after
-        this operation.
-
-        """
-        # Flush only if necessary, as this method needs to work on the on disk representation.
-        if not self._flushed:
-            self._flush()
-
-        # Make sure new term is in the vocabulary, then stage all the old and new terms for merging
-        self._execute("""
-            insert or ignore into disk_index.vocabulary(term) values(:new_term);
-
-            insert into term_merging
-                select (select id from disk_index.vocabulary where term = :new_term) as term_id,
-                    frame_id,
-                    sum(frequency),
-                    group_concat(positions, ',') -- Concatenate the JSON strings together.
-                from disk_index.term_posting post
-                inner join disk_index.frame
-                    on post.frame_id = frame.id
-                inner join disk_index.unstructured_field field
-                    on frame.field_id = field.id
-                where term_id in (select id from disk_index.vocabulary where term in (:old_term, :new_term))
-                    and field.name = :field
-                group by frame_id;
-
-            delete from disk_index.term_posting
-                where term_id in (select id from disk_index.vocabulary where term in (:old_term, :new_term))
-                    and frame_id in (select distinct frame_id from term_merging);
-
-            delete from disk_index.frame_posting
-                where term_id in (select id from disk_index.vocabulary where term in (:old_term, :new_term))
-                    and frame_id in (select distinct frame_id from term_merging);
-
-            delete from disk_index.term_statistics
-                where term_id in (select id from disk_index.vocabulary where term = :old_term)
-                    and field_id = (select id from disk_index.unstructured_field where name = :field);
-
-            insert or replace into disk_index.term_statistics
-                select term_id,
-                       (select id from disk_index.unstructured_field where name = :field),
-                       sum(frequency),
-                       count(frame_id),
-                       0 -- document count not currently fully implemented
-                from term_merging;
-
-            insert into disk_index.term_posting
-                select * from term_merging;
-
-            insert into disk_index.frame_posting(term_id, frame_id, frequency, positions)
-                select * from term_merging;
-
-            delete from term_merging;
-
-            """, {'new_term': new_term, 'old_term': old_term, 'field': field}
-        )
-
-    def _merge_bigrams(self, left_term, right_term, bigram, field, max_char_gap=2):
-        """
-        Merge adjacent occurences of left_term and right_term into the bigram phrase.
-
-        """
-        # Flush only if necessary, as this method needs to work on the on disk representation.
-        if not self._flushed:
-            self._flush()
-
-        bigram_rows = self._execute("""
-            insert or ignore into disk_index.vocabulary(term) values(:bigram);
-
-            -- Select rows for frames where both left term and right term occur.
-            with left as (
-                select
-                    term_id as left_term,
-                    frame_id,
-                    positions as left_positions,
-                    frequency as left_frequency
-                from disk_index.term_posting post
-                inner join disk_index.frame
-                    on post.frame_id = frame.id
-                where term_id = (select id from disk_index.vocabulary where term = :left_term)
-                    and frame.field_id = (select id from disk_index.unstructured_field where name = :field)
-            ),
-            right as (
-                select
-                    term_id as right_term,
-                    frame_id,
-                    positions as right_positions,
-                    frequency as right_frequency
-                from disk_index.term_posting post
-                inner join disk_index.frame
-                    on post.frame_id = frame.id
-                where term_id = (select id from disk_index.vocabulary where term = :right_term)
-                    and frame.field_id = (select id from disk_index.unstructured_field where name = :field)
-            )
-            insert into bigram_staging
-                select
-                    left.frame_id,
-                    (select id from vocabulary where term = :bigram) as new_term_id,
-                    left_term,
-                    left_positions,
-                    left_frequency,
-                    right_term,
-                    right_positions,
-                    right_frequency
-                from left
-                inner join right
-                    on left.frame_id = right.frame_id;
-
-            delete from disk_index.term_posting
-                where term_id in (select id from disk_index.vocabulary where term in (:left_term, :right_term))
-                    and frame_id in (select distinct frame_id from bigram_staging);
-
-            delete from disk_index.frame_posting
-                where term_id in (select id from disk_index.vocabulary where term in (:left_term, :right_term))
-                    and frame_id in (select distinct frame_id from bigram_staging);
-
-            -- Select out the rows to merge the positions of
-            select * from bigram_staging;
-
-            """, {'left_term': left_term, 'right_term': right_term, 'bigram': bigram, 'field': field}
-        )
-
-        def insert_row(values):
-            self._execute('insert into bigram_merging values(?, ?, ?, ?)', values)
-
-        for frame_id, bigram_id, left_id, left_positions, _, right_id, right_positions, _ in bigram_rows:
-
-            if left_id != right_id:  # Different left and right terms
-                left = [(start, end, 0) for start, end in json.loads('[{}]'.format(left_positions))]
-                right = [(start, end, 1) for start, end in json.loads('[{}]'.format(right_positions))]
-                sorted_positions = sorted(left + right)
-
-                # Sort positions, then merge those that match the sequence
-                merged_positions = []
-                final_left = []
-                final_right = []
-
-                merged = False
-                for first, second in zip(sorted_positions, sorted_positions[1:]):
-                    if merged:  # second term has been consumed, so move along
-                        merged = False
-                        continue
-                    # It's a bigram if the left term is follwed by the right term, and they are close enough.
-                    if (
-                        first[2] == 0 and second[2] == 1 and
-                        # Don't attempt to handle overlapping terms
-                        0 < second[0] - first[1] <= max_char_gap
-                    ):
-                        merged_positions.append([first[0], second[1]])
-                        merged = True
-                    # Not a bigram - keep the positions associated with that term.
-                    else:
-                        if first[2] == 0:
-                            final_left.append(first[:2])
-                        else:  # Avoid adding a repeated term twice.
-                            final_right.append(first[:2])
-                else:  # The last position if it wasn't merged.
-                    if not merged:
-                        if second[2] == 0:
-                            final_left.append(second[:2])
-                        else:  # Avoid adding a repeated term twice.
-                            final_right.append(second[:2])
-
-                if final_left:
-                    insert_row([left_id, frame_id, len(final_left), json.dumps(final_left)[1:-1]])
-                if final_right:
-                    insert_row([right_id, frame_id, len(final_right), json.dumps(final_right)[1:-1]])
-                if merged_positions:
-                    insert_row([bigram_id, frame_id, len(merged_positions), json.dumps(merged_positions)[1:-1]])
-
-            else:  # Special case for the same term occuring in a row.
-                positions = sorted([(start, end, 0) for start, end in json.loads('[{}]'.format(left_positions))])
-
-                merged_positions = []
-                final = []
-                merged = False
-
-                for first, second in zip(positions, positions[1:]):
-                    if merged:  # second term has been consumed, so move along
-                        merged = False
-                        continue
-                    if 0 < second[0] - first[1] <= max_char_gap:
-                        merged_positions.append([first[0], second[1]])
-                        merged = True
-                    else:
-                        final.append(first[:2])
-                else:  # Don't forget the last position if it wasn't merged.
-                    if not merged:
-                        final.append(second[:2])
-
-                if final:
-                    insert_row([left_id, frame_id, len(final), json.dumps(final)[1:-1]])
-                if merged_positions:
-                    insert_row([bigram_id, frame_id, len(merged_positions), json.dumps(merged_positions)[1:-1]])
-
-        # Finally, insert all the new values and update the term_statistics
-        self._execute("""
-            insert into disk_index.frame_posting(term_id, frame_id, frequency, positions)
-                select *
-                from bigram_merging;
-
-            insert into disk_index.term_posting(term_id, frame_id, frequency, positions)
-                select *
-                from bigram_merging;
-
-            insert or replace into disk_index.term_statistics(term_id, field_id, frequency, frames_occuring)
-                select
-                    term_id,
-                    field_id,
-                    sum(frequency) as frequency,
-                    count(frame_id) as frames_occuring
-                from disk_index.term_posting post
-                inner join disk_index.frame
-                    on frame.id = post.frame_id
-                where frame.field_id in (select id from disk_index.unstructured_field where name = :field)
-                    and term_id in (
-                        select id from disk_index.vocabulary where term in (:left_term, :right_term, :bigram)
-                    )
-                group by term_id, field_id;
-
-            delete from bigram_staging;
-            delete from bigram_merging;
-        """, {'left_term': left_term, 'right_term': right_term, 'bigram': bigram, 'field': field}
-        )
-
     def add_unstructured_fields(self, field_names):
         """Register an unstructured field on the index. """
         for f in field_names:
@@ -452,7 +211,7 @@ class SqliteWriter(StorageWriter):
                     field_name: list of string representations of each frames
                 }
                 - a dictionary {
-                    field_name: list of {term: [[word1 boundary], [word2 boundary]]} vectors for each frame
+                    field_name: list of {term: [[word1 token_position], [word2 token_position]]} vectors for each frame
                 }
             For the frame data (3rd and 4th elements), the frames should be in document sequence order
             and there should be a one-one correspondence between frame representations and term:frequency vectors.
@@ -512,7 +271,7 @@ class SqliteWriter(StorageWriter):
                 )
                 insert_term_data = (
                     # The leading and trailing [] are stripped so positions can be concatenated as strings.
-                    (frame_count + self.frame_no, term, len(positions), json.dumps(positions)[1:-1])
+                    (frame_count + self.frame_no, term, len(positions), _bitwise_encode(positions))
                     for frame_count, frame_data in enumerate(frame_term_data)
                     for term, positions in frame_data.iteritems()
                 )
@@ -525,6 +284,7 @@ class SqliteWriter(StorageWriter):
                 self._execute('release document')  # rollup this savepoint into the transaction.
                 self.frame_no += total_frames
                 self.doc_no += 1
+
             except Exception as e:
                 self._execute('rollback to savepoint document')
                 raise e
@@ -586,7 +346,8 @@ class SqliteReader(StorageReader):
     """
 
     def __init__(self, path):
-        """Open a reader for the given storage location."""
+        """Open or create a reader for the given storage location."""
+
         self._db_path = path
         self._db = os.path.join(path, 'storage.db')
 
@@ -698,7 +459,7 @@ class SqliteReader(StorageReader):
         return frequencies
 
     def _iterate_positions(self, terms=None, include_fields=None, exclude_fields=None):
-        """Iterate through the positions index.
+        """Iterate through the positions index, giving frame ids and frequencies for matching terms.
 
         By default, all terms are iterated. Optionally a list of terms can be provided.
 
@@ -727,7 +488,7 @@ class SqliteReader(StorageReader):
         data = (fields + [term] for term in terms)
         frames = self._executemany(
             """
-            select vocab.term, frame.id, field.name, post.positions
+            select vocab.term, frame.id, field.name, post.frequency
             from term_posting post
             inner join vocabulary vocab
                 on vocab.id = post.term_id
@@ -743,15 +504,15 @@ class SqliteReader(StorageReader):
 
         current_term = None
 
-        for term, frame_id, field_name, term_positions in frames:
+        for term, frame_id, field_name, frequency in frames:
             if current_term is None:
-                positions = {frame_id: sorted(json.loads('[{}]'.format(term_positions)))}
+                positions = {frame_id: frequency}
                 current_term = term
             elif term == current_term:
-                positions[frame_id] = sorted(json.loads('[{}]'.format(term_positions)))
+                positions[frame_id] = frequency
             else:
                 yield current_term, positions
-                positions = {frame_id: sorted(json.loads('[{}]'.format(term_positions)))}
+                positions = {frame_id: frequency}
                 current_term = term
         else:
             if current_term is not None:
@@ -759,7 +520,7 @@ class SqliteReader(StorageReader):
 
     def iterate_associations(self, term=None, association=None, include_fields=None, exclude_fields=None):
         """
-        Term associations for this index.
+        Term associations for this Index.
 
         This is used to record when two terms co-occur in a frame. Be aware that only 1 co-occurrence for two terms
         is recorded per frame no matter the frequency of each term. The format is as follows::
@@ -841,8 +602,6 @@ class SqliteReader(StorageReader):
         else:  # Make sure to yield the final row.
             if current_term is not None:
                 yield current_term, current_dict
-            else:
-                yield None, {}
 
     def count_documents(self):
         """Returns the number of documents in the index."""
@@ -901,6 +660,62 @@ class SqliteReader(StorageReader):
                 fields
             )
 
+    def iterate_term_frequency_vectors(self, weighting='tf', include_fields=None, exclude_fields=None, frame_ids=None):
+        """
+        Iterates through sparse term_vectors for frames in the index.
+
+        Currently only term frequency 'tf' weighting is supported.
+
+        If frame_ids is provided, then the include_fields and exclude_fields arguments will be ignored.
+
+        """
+
+        if frame_ids is None:
+            where_clause, fields = self._fielded_where_clause(include_fields, exclude_fields)
+
+            field_join = """
+                inner join frame
+                    on frame.id = frame_posting.frame_id
+                inner join unstructured_field field
+                    on field.id = frame.field_id
+            """ if fields else ''
+            rows = self._execute("""
+                select frame_id, term, frequency
+                from frame_posting
+                inner join vocabulary
+                    on frame_posting.term_id = vocabulary.id
+                {}
+                {}
+                order by frame_id
+            """.format(field_join, where_clause), fields)
+        else:
+            rows = self._executemany("""
+                select frame_id, term, frequency
+                from frame_posting
+                inner join vocabulary
+                    on frame_posting.term_id = vocabulary.id
+                where frame_id = ?
+            """, ((i,) for i in frame_ids))
+
+        current_frame = None
+
+        for frame_id, term, frequency in rows:
+            if current_frame is None:
+                term_freqs = {term: frequency}
+                current_frame = frame_id
+
+            elif current_frame == frame_id:
+                term_freqs[term] = frequency
+
+            else:
+                yield current_frame, term_freqs
+                current_frame = frame_id
+                term_freqs = {term: frequency}
+
+        else:  # Make sure to yield the final row.
+            if current_frame is not None:
+                yield current_frame, term_freqs
+
     def iterate_metadata(self, include_fields=None, exclude_fields=None, frames=True, text_field=None):
         """
         Get the metadata index.
@@ -958,6 +773,143 @@ class SqliteReader(StorageReader):
                 document_ids = [document_id]
         else:  # Make sure to yield the final row.
             yield current_field, current_value, document_ids
+
+    def iterate_bigram_positions(self, bigrams, include_fields=None, exclude_fields=None):
+        """Return an iterator of (left_term, right_term, frame_id, frequency) tuples for the specified list of bigrams.
+
+        Bigrams are supplied as a list of tuples: [('apple', 'pie'), ('whipped', 'cream')].
+
+        Currently, only exact matches for each term are considered - if one of the terms in the bigram occurs
+        after the 63rd position in a frame it is not considered a match.
+
+        """
+        where_clause, fields = self._fielded_where_clause(include_fields, exclude_fields)
+
+        if fields:
+            extra_join = """
+                inner join frame
+                    on frame.id = right_post.frame_id
+                inner join unstructured_field field
+                    on field.id = frame.field_id
+            """
+            # Mangle the normal where clause for fielded search: this query is difficult to structure to match this.
+            extra_where = 'and ' + where_clause[5:]
+        else:
+            extra_where = extra_join = ''
+
+        query_data = (list(bigram) + fields for bigram in bigrams)
+        bigrams = self._executemany("""
+            select
+                left_vocab.term,
+                right_vocab.term,
+                left_post.frame_id,
+                left_post.positions & (right_post.positions >> 1) as matched_positions
+            from term_posting left_post
+            inner join term_posting right_post
+                on left_post.frame_id = right_post.frame_id
+            inner join vocabulary left_vocab
+                on left_vocab.id = left_post.term_id
+                and left_vocab.term = ?
+            inner join vocabulary right_vocab
+                on right_vocab.id = right_post.term_id
+                and right_vocab.term = ?
+            {}
+            where
+                -- Exclude approximate positions indexes
+                left_post.positions > 0
+                and right_post.positions > 0
+                -- And they actually have matching positions
+                and matched_positions > 0
+                {}
+        """.format(extra_join, extra_where), query_data
+        )
+
+        for left_term, right_term, frame_id, positions in bigrams:
+            yield ((left_term, right_term), frame_id, _count_bitwise_matches(positions))
+
+    def find_significant_bigrams(self, include_fields=None, exclude_fields=None, min_count=5, threshold=40):
+        """Find significant collocations of words.
+
+        Currently operates over all fields in the index.
+
+        Currently, only exact matches for each term are considered - if one of the terms in the bigram occurs
+        after the 63rd position in a frame it is not considered a match.
+
+        Algorithm Notes
+
+        The formula for calculating bi-gram score is inspired by the Gensim implementation of phrase detection from the
+        Mikolov et al paper, "Distributed Representations of Words and Phrases and their Compositionality".
+
+        score(a, b) = freq(a, b) * vocab_size / (freq(a) * freq(b))
+
+        Currently the frequencies are the number of frames a bigram/unigram occurs in.
+
+        Args
+
+            min_count: specifies the minimum number of times a bigram must occur to be considered. It is also
+                used to prefilter the vocabulary for terms that don't occur enough to form a bigram.
+            threshold: the value of the statistical threshold used to determine if a phrase is a match or not.
+
+        """
+        where_clause, fields = self._fielded_where_clause(include_fields, exclude_fields)
+
+        # If fields are specified, we have some extra work to do.
+        if fields:
+            post_join = """
+                inner join frame
+                    on frame.id = right_post.frame_id
+                inner join unstructured_field field
+                    on field.id = frame.field_id
+            """
+            # Mangle the normal where clause for fielded search: this query is difficult to structure to match this.
+            post_where = 'and ' + where_clause[5:]
+            term_join = 'inner join unstructured_field field on field.id = ts.field_id and ' + where_clause[5:]
+        else:
+            post_where = post_join = term_join = ''
+
+        bigrams = self._execute("""
+            with bigrams as (
+                select
+                    left_post.term_id as left_id,
+                    right_post.term_id as right_id,
+                    count(*) * 1.0 as bigram_count
+                from term_posting left_post
+                inner join frame_posting right_post
+                    on left_post.frame_id = right_post.frame_id
+                {}
+                where
+                    -- Exclude approximate positions indexes
+                    left_post.positions > 0
+                    and right_post.positions > 0
+                    -- And they actually have matching positions
+                    and (left_post.positions & (right_post.positions >> 1)) > 0
+                    {}
+                group by left_post.term_id, right_post.term_id
+                having bigram_count > ?
+            ),
+            field_statistics as (
+                select ts.term_id, term, sum(frames_occuring) as frames_occuring
+                from term_statistics ts
+                inner join vocabulary
+                    on vocabulary.id = ts.term_id
+                {}
+                group by ts.term_id, term
+            )
+            select left_stats.term, right_stats.term
+            from bigrams
+            inner join field_statistics left_stats
+                on left_stats.term_id = bigrams.left_id
+            inner join field_statistics right_stats
+                on right_stats.term_id = bigrams.right_id
+            where (
+                bigram_count * (select count(*) from field_statistics) /
+                (1.0 * left_stats.frames_occuring * right_stats.frames_occuring)
+            ) > ?
+            """.format(post_join, post_where, term_join),
+            fields + [min_count] + fields + [threshold]
+        )
+
+        return bigrams
 
     def get_settings(self, names):
         """Get the settings identified by the given names. """
@@ -1021,3 +973,48 @@ class SqliteReader(StorageReader):
 
 
 SqliteStorage = Storage(SqliteReader, SqliteWriter)
+
+
+def _bitwise_encode(ordinal_positions):
+    """
+    Converts the sorted list of integers to a bitstring.
+
+    The integer i is indicated in the positions by setting the i'th bit of the string to 1.
+
+    Superpositions of integers up to 62 (positions 0, 1, ... 62) can be represented exactly.
+
+    For integers larger than 62, an approximate matching scheme is used: the position i % 63
+    is recorded instead. If the match is approximate, the high bit will set: the output integer is
+    negative if the match is approximate.
+
+    """
+
+    p = 0
+
+    for i in ordinal_positions:
+        p |= 1 << i % 63
+
+    if i > 62:
+        p = -p
+
+    return p
+
+
+def _count_bitwise_matches(position_bitstring):
+    """ Count the number of matches (number of bits set to 1) indicated by the given bitstring.
+
+    If the high bit is set in the bitstring, this will return 0.
+
+    This uses Kernighan's algorithm, and is faster in the case of a small number of bits set.
+
+    """
+    if position_bitstring <= 0:
+        return 0
+
+    n = 0
+
+    while position_bitstring > 0:
+        position_bitstring &= position_bitstring - 1
+        n += 1
+
+    return n


### PR DESCRIPTION
Allow deferral of all model related decisions to after indexing by limiting the scope of indexing changes.

1. Remove destructive merging operations from the writer
2. Expose new reader functions get_case_fold_terms, detect_significant_ngrams and search_ngrams that return lists of case fold pairs, lists of bigrams and frames containing bigrams respectively.
3. Change defaults for tokenization with respect to stopwords. By default nothing is stopped.

New reader functions expose more sophisticated field selection functionality: it is possible to specify a list of include_fields or a list of exclude_fields -- the included fields in the call will be treated as a single logical field.

Ngram (currently only bigram) searching is backed by a new bitstring positions index.