### PR TITLE
Allow storage of per frame information in the form of attributes

### DIFF
--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -819,6 +819,7 @@ class IndexReader(object):
             frame = json.loads(row[4])
             frame['_id'] = row[0]
             frame['_doc_id'] = row[1]
+            frame['_attributes'] = {key: value for key, value in self.__storage.iterate_frame_attributes([row[0]])}
             yield row[0], frame
 
     def get_frame_ids(self, field):

--- a/caterpillar/processing/index.py
+++ b/caterpillar/processing/index.py
@@ -857,19 +857,22 @@ class IndexReader(object):
 
     def get_metadata(self, text_field=None):
         """
-        Get the metadata index.
+        Iterate through the entire metadata index.
 
-        This method is a generator that yields a key, value tuple. The index is in the following format::
+        This method is a generator that yields an inverted index that shows
+        which frames or documents have a particular metadata field and the
+        value of that that metadata field. A tuple of the field name and the
+        corresponding values: frame_ids mapping is yielded on every iteration:
 
-            {
-                "field_name": {
-                    "value": ["frame_id", "frame_id"],
-                    "value": ["frame_id", "frame_id"],
-                    "value": ["frame_id", "frame_id"],
+
+            (
+                "attribute_name", {
+                    "value": ["frame_id1", "frame_id2"],
+                    "value": ["frame_id3"],
+                    "value": ["frame_id4", "frame_id5", ..., "frame_idn"],
                     ...
-                },
-                ...
-            }
+                }
+            )
 
         The optional text_field limits the returned values to frames from that field.
 
@@ -893,21 +896,34 @@ class IndexReader(object):
 
     def get_attributes(self, include_fields=None, exclude_fields=None, return_documents=False):
         """
-        Get the metadata index.
+        Iterate through the entire attribute index for either frames or documents.
 
-        This method is a generator that yields a key, value tuple. The index is in the following format::
+        This method is a generator that yields an inverted index that shows
+        which frames or documents have a particular attribute and the value of
+        that that attribute. A tuple of the attribute_name and the
+        corresponding values: frame_ids mapping is yielded on every iteration:
 
-            {
-                "field_name": {
-                    "value": ["frame_id", "frame_id"],
-                    "value": ["frame_id", "frame_id"],
-                    "value": ["frame_id", "frame_id"],
+            (
+                "attribute_name", {
+                    "value": ["frame_id1", "frame_id2"],
+                    "value": ["frame_id3"],
+                    "value": ["frame_id4", "frame_id5", ..., "frame_idn"],
                     ...
-                },
-                ...
-            }
+                }
+            )
 
-        The optional text_field limits the returned values to frames from that field.
+
+        Args
+
+            include_fields: list of unstructured fields to include in the analysis.
+                By default this is None, and all fields are included if exclude_fields is also None.
+
+            exclude_fields: list of unstructured fields to exclude from the analysis.
+                If include_fields is not None, this argument is ignored.
+
+            return_documents: if True, return documents with any frame matching that attribute-value
+                paid. Default is False. Because attributes correspond to the properties of an
+                individual frame, the resulting index needs to be interpreted with care.
 
         """
         metadata = self.__storage.iterate_attributes(

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -275,6 +275,19 @@ def test_index_alice_attributes(index_dir):
             [text2_attribute_index.get(i, None) is None for i in ['numerical_score', 'sentiment', 'named_entity']]
         )
 
+        with IndexReader(index_dir) as reader:
+            attribute_frames = reader.get_frames(None, frame_ids=range(20))
+            for f_id, frame in attribute_frames:
+                assert frame['_attributes']['numerical_score'] == f_id // 10
+                if f_id % 3 == 0:
+                    assert frame['_attributes']['sentiment'] == 'positive'
+                else:
+                    assert 'sentiment' not in frame['_attributes']
+                if f_id % 11 == 0:
+                    assert frame['_attributes']['named_entity']
+                else:
+                    assert 'named_entity' not in frame['_attributes']
+
 
 def test_index_writer_rollback(index_dir):
     with open(os.path.abspath('caterpillar/test_resources/alice_test_data.txt'), 'r') as f:

--- a/caterpillar/processing/test/test_index.py
+++ b/caterpillar/processing/test/test_index.py
@@ -208,6 +208,74 @@ def test_index_alice(index_dir):
             assert reader.get_frame_count('text') == 2
 
 
+def test_index_alice_attributes(index_dir):
+    """Whole bunch of functional tests on the index."""
+    with open(os.path.abspath('caterpillar/test_resources/alice_test_data.txt'), 'r') as f:
+        data = f.read()
+        analyser = TestAnalyser()
+        writer = IndexWriter(index_dir, IndexConfig(SqliteStorage,
+                                                    Schema(text1=TEXT(analyser=analyser), text2=TEXT,
+                                                           document=TEXT(analyser=analyser, indexed=False),
+                                                           blank=NUMERIC(indexed=True), ref=ID(indexed=True))))
+        with writer:
+            writer.add_document(text1=data, text2=data, document='alice.txt', blank=None, ref=123, frame_size=2)
+
+        # Label all the frames with some nonsense attributes
+        with IndexReader(index_dir) as reader:
+            frame_ids = list(reader.get_frame_ids('text1'))
+
+        attribute_index = {}
+
+        for f_id in frame_ids:
+            attribute_index[f_id] = {}
+            attribute_index[f_id]['numerical_score'] = f_id // 10
+            if f_id % 3 == 0:
+                attribute_index[f_id]['sentiment'] = 'positive'
+            if f_id % 11 == 0:
+                attribute_index[f_id]['named_entity'] = str(f_id)
+
+        with writer:
+            writer.append_frame_attributes(attribute_index)
+
+        with IndexReader(index_dir) as reader:
+            text1_attribute_index = list(reader.get_attributes(include_fields=['text1']))
+            text1_attribute_counts = {}
+            for attribute, values in text1_attribute_index:
+                text1_attribute_counts[attribute] = {}
+                for value, frames in values.iteritems():
+                    text1_attribute_counts[attribute][value] = len(frames)
+
+            text2_attribute_index = {key: values for key, values in reader.get_attributes(include_fields=['text2'])}
+
+            all_attribute_index = list(reader.get_attributes())
+            all_attribute_counts = {}
+            for attribute, values in all_attribute_index:
+                all_attribute_counts[attribute] = {}
+                for value, frames in values.iteritems():
+                    all_attribute_counts[attribute][value] = len(frames)
+
+            doc_attribute_index = list(reader.get_attributes(return_documents=True))
+            doc_attribute_counts = {}
+            for attribute, values in doc_attribute_index:
+                doc_attribute_counts[attribute] = {}
+                for value, docs in values.iteritems():
+                    doc_attribute_counts[attribute][value] = len(docs)
+
+        assert text1_attribute_counts['sentiment']['positive'] == 17
+        assert text1_attribute_counts['numerical_score'][1] == 10
+        assert text1_attribute_counts == all_attribute_counts
+        assert all(i == 1 for i in text1_attribute_counts['named_entity'].values())
+
+        assert all([
+            count == 1 for attribute, values in doc_attribute_counts.iteritems()
+            for value, count in values.iteritems()
+        ])
+
+        assert all(
+            [text2_attribute_index.get(i, None) is None for i in ['numerical_score', 'sentiment', 'named_entity']]
+        )
+
+
 def test_index_writer_rollback(index_dir):
     with open(os.path.abspath('caterpillar/test_resources/alice_test_data.txt'), 'r') as f:
         data = f.read()

--- a/caterpillar/storage/_sqlite_schema.py
+++ b/caterpillar/storage/_sqlite_schema.py
@@ -553,22 +553,31 @@ insert into disk_index.attribute(type, value)
             and attr.value = at.value
     );
 
-/* Add to the attribute-frame postings indexes */
+/* Add to the attribute-frame postings indexes
+
+Note that we're making sure the frames actually exist.
+
+*/
+
 insert into disk_index.frame_attribute_posting(frame_id, attribute_id)
-    select frame_id, id
+    select frame_id, attribute.id
     from attribute_posting post
     inner join disk_index.attribute
         on attribute.type = post.type
         and attribute.value = post.value
-    order by frame_id, id;
+    inner join disk_index.frame
+        on frame.id = post.frame_id
+    order by frame_id, attribute.id;
 
 insert into disk_index.attribute_frame_posting(frame_id, attribute_id)
-    select frame_id, id
+    select frame_id, attribute.id
     from attribute_posting post
     inner join disk_index.attribute
         on attribute.type = post.type
         and attribute.value = post.value
-    order by id, frame_id;
+    inner join disk_index.frame
+        on frame.id = post.frame_id
+    order by attribute.id, frame_id;
 
 
 /* Update the statistics by combining on-disk, deleted and new values */

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -294,6 +294,15 @@ class SqliteWriter(StorageWriter):
         else:
             raise ValueError('Unknown document_format {}'.format(document_format))
 
+    def append_frame_attributes(self, attribute_index):
+        """Append the attributes for the given frames to the index. """
+        row_generator = (
+            (frame_id, attribute_type, attribute_value)
+            for frame_id, values in attribute_index.iteritems()
+            for attribute_type, attribute_value in values.iteritems()
+        )
+        self._executemany('insert into attribute_posting values (?, ?, ?)', row_generator)
+
     def delete_documents(self, document_ids):
         """Delete a document with the given id from the index. """
         document_id_gen = ((document_id,) for document_id in document_ids)
@@ -788,6 +797,63 @@ class SqliteReader(StorageReader):
         else:  # Make sure to yield the final row.
             yield current_field, current_value, document_ids
 
+    def iterate_attributes(self, include_fields=None, exclude_fields=None, return_documents=False):
+        """
+        Get the frame-attribute index.
+
+        This method is a generator that yields tuples (attribute_type, value, [frame_ids])
+
+        The return_documents flag indicates whether the return values should be broadcast to frame_ids (default)
+        or document_ids.
+
+        """
+        where_clause, fields = self._fielded_where_clause(include_fields, exclude_fields)
+
+        frames_or_documents = 'document_id' if return_documents else 'frame_id'
+
+        if fields:
+            frame_join = """
+            inner join frame
+                on frame.id = fp.frame_id
+                and field_id in (select id from unstructured_field field {})
+            """.format(where_clause)
+        elif return_documents:
+            frame_join = """
+                inner join frame on frame.id = fp.frame_id
+            """
+        else:
+            frame_join = ''
+
+        query = """
+            select {0}
+                attribute.type,
+                attribute.value,
+                {1} as identifier
+            from frame_attribute_posting fp
+                {2}
+            inner join attribute
+               on attribute.id = fp.attribute_id
+            order by type, value
+        """.format('distinct' if return_documents else '', frames_or_documents, frame_join)
+
+        rows = self._execute(query, fields)
+
+        current_field, current_value, document_id = next(rows)
+        document_ids = [document_id]
+
+        for row in rows:
+            field, value, document_id = row
+            # Rows are sorted by field, value, so as soon as the change can yield
+            if field == current_field and value == current_value:
+                document_ids.append(document_id)
+            else:
+                yield current_field, current_value, document_ids
+                current_field = field
+                current_value = value
+                document_ids = [document_id]
+        else:  # Make sure to yield the final row.
+            yield current_field, current_value, document_ids
+
     def iterate_bigram_positions(self, bigrams, include_fields=None, exclude_fields=None):
         """Return an iterator of (left_term, right_term, frame_id, frequency) tuples for the specified list of bigrams.
 
@@ -1267,6 +1333,84 @@ class SqliteReader(StorageReader):
         )
 
         return results
+
+    def filter_attributes(
+        self, attributes, return_documents=False, include_fields=None, exclude_fields=None, limit=0, pagination_key=None
+    ):
+        """
+        Return frames or documents containing specific attributes.
+
+        Currently this is a very thin skin over the underlying tables - expect this interface to
+        be merged with regular term filtering and the schema field API in the future. No type conversion or checking
+        is performed - the attribute comparisons will be directly used as bound parameters in an SQL query.
+
+        Don't rely on this API to be stable!
+
+        """
+        operator_whitelist = {'=', '>', '>=', '<', '<='}
+        where_clause, fields = self._fielded_where_clause(include_fields, exclude_fields)
+        parameters = []
+
+        if fields:
+            field_clause = """
+                inner join frame
+                    on afp.frame_id = frame.id
+                    and field_id in (select id from unstructured_field field {})
+            """.format(where_clause)
+        elif return_documents:
+            field_clause = """
+                inner join frame
+                    on afp.frame_id = frame.id
+            """
+        else:
+            field_clause = ''
+
+        attribute_block = """
+            select {0}
+            from attribute
+            cross join attribute_frame_posting afp
+                on afp.attribute_id = attribute.id
+                {1}
+            where
+                attribute.type = ?
+                {2}
+                {3}
+        """
+
+        documents_or_frames = 'document_id' if return_documents else 'frame_id'
+        pagination_clause = 'and {} > ?'.format(documents_or_frames) if pagination_key is not None else ' '
+
+        attribute_blocks = []
+
+        for attribute_type, value_comparisons in attributes.items():
+            if any(operator not in operator_whitelist for operator in value_comparisons.keys()):
+                raise ValueError('Only {} operators are supported.'.format(operator_whitelist))
+
+            op_values = value_comparisons.items()
+            operator_clauses = '\n'.join(['and value {} ?'.format(op) for op, _ in op_values])
+            parameters.append(attribute_type)
+            parameters.extend(fields)
+            parameters.extend([v for _, v in op_values])
+            if pagination_key is not None:
+                parameters.append(pagination_key)
+
+            attribute_blocks.append(
+                attribute_block.format(
+                    documents_or_frames, field_clause, operator_clauses, pagination_clause)
+            )
+
+        if limit:
+            limit_clause = 'limit ?'
+            parameters.append(limit)
+        else:
+            limit_clause = ''
+
+        full_query = '{0} {1}'.format("""
+            intersect
+        """.join(attribute_blocks), limit_clause
+        )
+
+        return self._execute(full_query, parameters)
 
     def find_significant_bigrams(self, include_fields=None, exclude_fields=None, min_count=5, threshold=40):
         """Find significant collocations of words.

--- a/caterpillar/storage/sqlite.py
+++ b/caterpillar/storage/sqlite.py
@@ -797,6 +797,17 @@ class SqliteReader(StorageReader):
         else:  # Make sure to yield the final row.
             yield current_field, current_value, document_ids
 
+    def iterate_frame_attributes(self, frame_ids):
+        """Iterate through the attributes of the given frames. """
+        return self._executemany("""
+            select
+                type, value
+            from frame_attribute_posting post
+            inner join attribute
+                on attribute.id = post.attribute_id
+            where frame_id = ?
+        """, [(f_id,) for f_id in frame_ids])
+
     def iterate_attributes(self, include_fields=None, exclude_fields=None, return_documents=False):
         """
         Get the frame-attribute index.


### PR DESCRIPTION
Allow storage of structured/semi-structured data on a per frame
basis. This allows per frame annotation of attributes, similar
to the current document level metadata storage.

Attributes are stored using in an append only manner using:
        - writer.append_frame_attributes(attribute_index)

Attributes are accessible in two ways:
	- reader.get_attributes()
		Works very similarly to get_metadata, and allows working with
		the whole attribute index
	- reader.filter_attributes()
		Allows filtering by attributes and is compatible with the rest
		of the filter functions

Limitations
	- Only directly supports native SQLite types - no data validation
	  or processing is supported
	- Attributes are append only, after indexing - a known frame_id
	  must be present to add an attribute to the index
	- Only basic equality and range predicated are supported